### PR TITLE
tabular data support in ScriptHelper

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Row.java
+++ b/core/src/main/java/io/github/jdbcx/Row.java
@@ -16,6 +16,7 @@
 package io.github.jdbcx;
 
 import java.io.Serializable;
+import java.util.LinkedList;
 import java.util.List;
 
 import io.github.jdbcx.data.DefaultRow;
@@ -31,6 +32,8 @@ public interface Row extends Serializable {
             row = of(fields);
         } else if (value instanceof Row) {
             row = (Row) value;
+        } else if (value instanceof Iterable) {
+            row = of(fields, (Iterable<?>) value);
         } else if (value instanceof Value[]) {
             row = of(fields, (Value[]) value);
         } else if (value instanceof String[]) {
@@ -43,6 +46,18 @@ public interface Row extends Serializable {
             row = of(fields, new StringValue(value));
         }
         return row;
+    }
+
+    static Row of(List<Field> fields, Iterable<?> iterable) {
+        if (iterable == null) {
+            return new DefaultRow(fields);
+        }
+
+        List<Value> list = new LinkedList<>();
+        for (Object obj : iterable) {
+            list.add(new StringValue(obj));
+        }
+        return new DefaultRow(fields, list.toArray(new Value[0]));
     }
 
     static Row of(List<Field> fields, Object[] array) {

--- a/core/src/main/java/io/github/jdbcx/data/DefaultRow.java
+++ b/core/src/main/java/io/github/jdbcx/data/DefaultRow.java
@@ -86,4 +86,16 @@ public final class DefaultRow implements Row {
     public int size() {
         return size;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("Row[");
+        for (int i = 0; i < size; i++) {
+            builder.append(fields.get(i).name()).append('=').append(values[i].asString()).append(',');
+        }
+        if (size > 0) {
+            builder.setLength(builder.length() - 1);
+        }
+        return builder.append("]@").append(hashCode()).toString();
+    }
 }

--- a/core/src/test/java/io/github/jdbcx/RowTest.java
+++ b/core/src/test/java/io/github/jdbcx/RowTest.java
@@ -15,22 +15,47 @@
  */
 package io.github.jdbcx;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import io.github.jdbcx.data.LongValue;
 import io.github.jdbcx.data.StringValue;
 
 public class RowTest {
     @Test(groups = "unit")
     public void testConstructor() {
-        Assert.assertEquals(Row.of((String) null).values().size(), 1);
-        Assert.assertEquals(Row.of((String) null).value(0).asString(), "");
+        Row r = Row.of((String) null);
+        Assert.assertEquals(r.values().size(), 1);
+        Assert.assertEquals(r.value(0).asString(), "");
 
-        Assert.assertEquals(Row.of(Collections.emptyList(), new String[] { "2", "1" }).size(), 0);
-        Assert.assertEquals(Row.of(Collections.emptyList(), new String[] { "2", "1" }).values().size(), 2);
+        r = Row.of((Long) null);
+        Assert.assertEquals(r.values().size(), 1);
+        Assert.assertEquals(r.value(0).asString(), "");
 
-        Assert.assertEquals(Row.of(Collections.emptyList(), new StringValue("3")).value(0).asString(), "3");
+        r = Row.of(Collections.emptyList(), new String[] { "2", "1" });
+        Assert.assertEquals(r.size(), 0);
+        Assert.assertEquals(r.value(0).asString(), "2");
+        Assert.assertEquals(r.value(1).asString(), "1");
+        Assert.assertEquals(r.values().size(), 2);
+
+        r = Row.of(Collections.emptyList(), Arrays.asList(1, 2));
+        Assert.assertEquals(r.size(), 0);
+        Assert.assertEquals(r.value(0).asString(), "1");
+        Assert.assertEquals(r.value(1).asString(), "2");
+        Assert.assertEquals(r.values().size(), 2);
+
+        r = Row.of(Collections.singletonList(Field.of("name")), new StringValue("3"));
+        Assert.assertEquals(r.size(), 1);
+        Assert.assertEquals(r.value(0).asString(), "3");
+        Assert.assertEquals(r.values().size(), 1);
+
+        r = Row.of(Collections.singletonList(Field.of("name")), new StringValue("3"), new LongValue(4L));
+        Assert.assertEquals(r.size(), 1);
+        Assert.assertEquals(r.value(0).asString(), "3");
+        Assert.assertEquals(r.value(1).asString(), "4");
+        Assert.assertEquals(r.values().size(), 2);
     }
 }

--- a/core/src/test/java/io/github/jdbcx/data/IterableWrapperTest.java
+++ b/core/src/test/java/io/github/jdbcx/data/IterableWrapperTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2023, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.data;
+
+import java.util.Arrays;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Row;
+
+public class IterableWrapperTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        int index = 0;
+        for (Row r : new IterableWrapper(DefaultRow.defaultFields, Arrays.asList(1, 2))) {
+            Assert.assertEquals(r.value(0).asInt(), index + 1);
+            index++;
+        }
+        Assert.assertEquals(index, 2);
+    }
+}


### PR DESCRIPTION
```sql
{{ script: 
helper.table(
	['a','b','c'],    // fields
	[[3,2,1],[1,2,3]] // rows
)
}}
```