### PR TITLE
execute chained query and save result as variable

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Constants.java
+++ b/core/src/main/java/io/github/jdbcx/Constants.java
@@ -51,6 +51,10 @@ public final class Constants {
 
     public static final String RE_META_CHARS = "<([{\\^-=$!|]})?*+.>";
 
+    public static final String SCOPE_GLOBAL = "global";
+    public static final String SCOPE_THREAD = "thread";
+    public static final String SCOPE_QUERY = "query";
+
     public static final int DEFAULT_BUFFER_SIZE = 2048;
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 

--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -75,6 +75,11 @@ public final class Option implements Serializable {
     public static final Option CLASSPATH = Option
             .of(new String[] { "classpath", "Comma separated classpath for loading classes" });
 
+    public static final Option PRE_QUERY = Option
+            .of(new String[] { "pre.query", "Query must execute before the current one" });
+    public static final Option POST_QUERY = Option
+            .of(new String[] { "post.query", "Query must execute right after the current one" });
+
     /**
      * Path to config property file.
      */
@@ -138,7 +143,14 @@ public final class Option implements Serializable {
 
     public static final Option RESULT_FORMAT = Option
             .of(new String[] { "result.format", "Output format to use for query results." });
-    public static final Option RESULT_ID = Option.of(new String[] { "result.id", "Unique ID of the query result." });
+    public static final Option RESULT_VAR = Option
+            .of(new String[] { "result.var", "Unique variable name of the query result." });
+    public static final Option RESULT_REUSE = Option
+            .of(new String[] { "result.reuse", "Whether to reuse the result, only works when result.var is specified.",
+                    "true", "false" });
+    public static final Option RESULT_SCOPE = Option
+            .of(new String[] { "result.scope", "Scope of the result, only works when result.var is specified.",
+                    Constants.SCOPE_QUERY, Constants.SCOPE_THREAD, Constants.SCOPE_GLOBAL });
     public static final Option RESULT_JSON_PATH = Option
             .of(new String[] { "result.json.path",
                     "The JSON path to extract a value from the JSON query results. The extracted value will be converted to a string and escaped." });

--- a/core/src/main/java/io/github/jdbcx/interpreter/ScriptInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/ScriptInterpreter.java
@@ -40,11 +40,14 @@ public class ScriptInterpreter extends AbstractInterpreter {
 
     public static final String KEY_VARS = "vars";
 
+    public static final Option OPTION_VAR_CONTEXT = Option
+            .of(new String[] { "var.context", "Variable name of the query context", "context" });
     public static final Option OPTION_VAR_HELPER = Option
             .of(new String[] { "var.helper", "Variable name of the helper object", "helper" });
 
     public static final List<Option> OPTIONS = Collections.unmodifiableList(Arrays.asList(Option.EXEC_ERROR,
-            OPTION_TIMEOUT, ScriptExecutor.OPTION_LANGUAGE, ScriptExecutor.OPTION_BINDING_ERROR, OPTION_VAR_HELPER));
+            OPTION_TIMEOUT, ScriptExecutor.OPTION_LANGUAGE, ScriptExecutor.OPTION_BINDING_ERROR, OPTION_VAR_CONTEXT,
+            OPTION_VAR_HELPER));
 
     private final ScriptExecutor executor;
 
@@ -54,10 +57,14 @@ public class ScriptInterpreter extends AbstractInterpreter {
 
         OPTION_TIMEOUT.setDefaultValueIfNotPresent(config);
 
+        String varContext = OPTION_VAR_CONTEXT.getValue(config);
         String varHelper = OPTION_VAR_HELPER.getValue(config);
 
         Object map = context.get(KEY_VARS);
         Map<String, Object> vars = map instanceof Map ? (Map<String, Object>) map : new HashMap<>();
+        if (!Checker.isNullOrEmpty(varContext)) {
+            vars.put(varContext, context);
+        }
         if (!Checker.isNullOrEmpty(varHelper)) {
             vars.put(varHelper, ScriptHelper.getInstance());
         }

--- a/core/src/main/java/io/github/jdbcx/interpreter/VarInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/VarInterpreter.java
@@ -41,14 +41,16 @@ public class VarInterpreter extends AbstractInterpreter {
     public Result<String> interpret(String query, Properties props) {
         try {
             if (!Checker.isNullOrBlank(query)) {
-                final Properties conf = getContext().getCustomVariables();
+                final QueryContext context = getContext();
                 final String prefix = OPTION_PREFIX.getValue(props, defaultPrefix);
                 if (Checker.isNullOrEmpty(prefix)) {
-                    conf.putAll(Utils.toKeyValuePairs(query));
+                    for (Entry<String, String> entry : Utils.toKeyValuePairs(query).entrySet()) {
+                        context.setVariable(entry.getKey(), entry.getValue());
+                    }
                 } else {
                     Map<String, String> map = Utils.toKeyValuePairs(query);
                     for (Entry<String, String> entry : map.entrySet()) {
-                        conf.setProperty(prefix.concat(entry.getKey()), entry.getValue());
+                        context.setVariable(prefix.concat(entry.getKey()), entry.getValue());
                     }
                 }
             }

--- a/core/src/test/java/io/github/jdbcx/QueryContextTest.java
+++ b/core/src/test/java/io/github/jdbcx/QueryContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-2023, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QueryContextTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        try (QueryContext context = QueryContext.newContextForThread()) {
+            Assert.assertEquals(context.getScope(), Constants.SCOPE_THREAD);
+            Assert.assertEquals(context.getParent().getScope(), Constants.SCOPE_GLOBAL);
+        }
+
+        try (QueryContext context = QueryContext.newContext()) {
+            Assert.assertEquals(context.getScope(), Constants.SCOPE_QUERY);
+            Assert.assertEquals(context.getParent().getScope(), Constants.SCOPE_GLOBAL);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testVariable() {
+        final String uuid = UUID.randomUUID().toString();
+        try (QueryContext context = QueryContext.newContextForThread()) {
+            Assert.assertEquals(context.getVariable(uuid), null);
+            Assert.assertEquals(context.getVariable(uuid, "x"), "x");
+            context.setVariable(uuid, uuid);
+            Assert.assertEquals(context.getVariable(uuid), uuid);
+            context.removeVariable(uuid);
+            Assert.assertEquals(context.getVariable(uuid), null);
+            Assert.assertEquals(context.getVariable(uuid, "x"), "x");
+
+            context.getParent().setVariable(uuid, "1");
+            Assert.assertEquals(context.getVariable(uuid), "1");
+            context.setVariable(uuid, "2");
+            Assert.assertEquals(context.getVariable(uuid), "2");
+            Assert.assertEquals(context.getVariableInScope(Constants.SCOPE_GLOBAL, uuid), "1");
+            Assert.assertEquals(context.getVariableInScope(Constants.SCOPE_THREAD, uuid), "2");
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> context.getVariableInScope(Constants.SCOPE_QUERY, uuid));
+
+            Properties props = new Properties();
+            Assert.assertEquals(context.getParent().getVariables(), props);
+            props.setProperty(uuid, "1");
+            Assert.assertEquals(context.getParent().getMergedVariables(), props);
+
+            props.clear();
+            Assert.assertEquals(context.getVariables(), props);
+            props.setProperty(uuid, "2");
+            Assert.assertEquals(context.getMergedVariables(), props);
+        }
+    }
+}

--- a/docker/app/.jdbcx/web/baidu-auth.properties
+++ b/docker/app/.jdbcx/web/baidu-auth.properties
@@ -3,7 +3,8 @@ base.url=https://aip.baidubce.com/oauth/2.0/token
 url.template=${base.url}?grant_type=client_credentials&client_id=${baidu.api.key}&client_secret=${baidu.secret.key}
 request.headers=Content-Type=application/json,Accept=application/json
 request.template=""
-result.id=baidu_access_token
+result.var=baidu_access_token
+result.scope=global
 result.json.path=access_token
 
 # custom properties

--- a/docker/app/.jdbcx/web/baidu-llm.properties
+++ b/docker/app/.jdbcx/web/baidu-llm.properties
@@ -7,8 +7,8 @@ request.template={"messages":[{"role":"user","content":${}}],"temperature":0.2}
 request.headers=Content-Type=application/json
 request.encode=json
 result.json.path=result
+result.string.split=true
 
 # custom properties
-baidu_access_token=***
 baidu.api=chat
 baidu.model=completions

--- a/driver/src/main/java/io/github/jdbcx/driver/impl/DefaultStatement.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/impl/DefaultStatement.java
@@ -88,7 +88,7 @@ public class DefaultStatement extends DefaultResource implements Statement {
     protected List<String> handleResults(String query) throws SQLException {
         SQLWarning w = null;
         try (QueryContext context = manager.createContext()) {
-            final ParsedQuery pq = QueryParser.parse(query, context.getCustomVariables());
+            final ParsedQuery pq = QueryParser.parse(query, context.getVariables());
             final QueryBuilder builder = new QueryBuilder(context, pq, manager, queryResult);
             List<String> queries = builder.build();
             if (queries.isEmpty()) {

--- a/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
+++ b/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
@@ -80,7 +80,7 @@ public class WrappedDriverTest extends BaseIntegrationTest {
     }
 
     @Test(groups = { "unit" })
-    public void testCustomVariable() throws Exception {
+    public void testVariable() throws Exception {
         String url = "jdbcx:derby:memory:x;create=true";
         Properties props = new Properties();
         try (Connection conn = DriverManager.getConnection(url, props); Statement stmt = conn.createStatement()) {

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
@@ -350,4 +350,25 @@ public class QueryParserTest {
                         Arrays.asList(new ExecutableBlock(1, "var", props, "x=ch-dev ", false),
                                 new ExecutableBlock(3, "web", expectedProps, "my request ", true))));
     }
+
+    @Test(groups = { "unit" })
+    public void testPrePostQueries() {
+        Properties props = new Properties();
+        String str;
+
+        Assert.assertEquals(QueryParser.parse(str = "{{web(pre.query=,post.query=)}}", props),
+                new ParsedQuery(Arrays.asList("", ""), Arrays.asList(new ExecutableBlock(1, "web", props, "", true))));
+        Assert.assertEquals(QueryParser.parse(str = "{{web(pre.query='',post.query=\"\")}}", props),
+                new ParsedQuery(Arrays.asList("", ""), Arrays.asList(new ExecutableBlock(1, "web", props, "", true))));
+        Assert.assertEquals(QueryParser.parse(str = "{{web(pre.query=\"db: select 1\",post.query=\"\")}}", props),
+                new ParsedQuery(Arrays.asList("", "", ""),
+                        Arrays.asList(new ExecutableBlock(1, "db", props, "select 1", false),
+                                new ExecutableBlock(2, "web", props, "", true))));
+        Assert.assertEquals(
+                QueryParser.parse(str = "{{web(pre.query=\"db: select 1\",post.query='shell: select 2')}}", props),
+                new ParsedQuery(Arrays.asList("", "", "", ""),
+                        Arrays.asList(new ExecutableBlock(1, "db", props, "select 1", false),
+                                new ExecutableBlock(2, "web", props, "", true),
+                                new ExecutableBlock(3, "shell", props, "select 2", false))));
+    }
 }

--- a/driver/src/test/java/io/github/jdbcx/extension/WebDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/WebDriverExtensionTest.java
@@ -61,7 +61,7 @@ public class WebDriverExtensionTest extends BaseIntegrationTest {
                 Statement stmt = conn.createStatement()) {
             try (ResultSet rs = stmt
                     .executeQuery("{% var: theme=\u5927\u8BED\u8A00\u6A21\u578B %}\n" +
-                            "{{ web.baidu-llm(result.string.split=true): \u751F\u6210\u4E00\u4EFD\u4E0E${theme}\u6709\u5173\u7684\u5341\u5927\u4E8B\u5B9E\u3001\u7EDF\u8BA1\u6570\u636E\u548C\u8D8B\u52BF\u7684\u6E05\u5355\uFF0C\u5305\u62EC\u5176\u6765\u6E90 }}\n")) {
+                            "{{ web.baidu-llm(pre.query=web.baidu-auth): \u751F\u6210\u4E00\u4EFD\u4E0E${theme}\u6709\u5173\u7684\u5341\u5927\u4E8B\u5B9E\u3001\u7EDF\u8BA1\u6570\u636E\u548C\u8D8B\u52BF\u7684\u6E05\u5355\uFF0C\u5305\u62EC\u5176\u6765\u6E90 }}\n")) {
                 int count = 0;
                 while (rs.next()) {
                     Assert.assertNotNull(rs.getString(1));


### PR DESCRIPTION
before
```sql
-- 1. get access token
{{ web.baidu-auth }}

-- 2. chat using prompt template
{% var: theme=大语言模型 %}
{{ web.baidu-llm(baidu_access_token=***): 生成一份与${theme}有关的十大事实、统计数据和趋势的清单，包括其来源 }}
```

after
```sql
{% var: theme=大语言模型 %}
-- dependent query will be only executed once, because result.reuse=true and result.scope=global
{{ web.baidu-llm(pre.query=web.baidu-auth): 生成一份与${theme}有关的十大事实、统计数据和趋势的清单，包括其来源 }}
```