### PR TITLE
improve usability of dynamic query

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ JDBCX enhances the JDBC driver by supporting additional data formats, compressio
 
 ```sql
 -- https://clickhouse.com/docs/en/sql-reference/aggregate-functions/parametric-functions#retention
+{% var(delimiter=;): dates=['2020-01-01','2020-01-02','2020-01-03'] %}
 SELECT
     uid,
-    retention({{ script: "date='" + ['2020-01-01','2020-01-02','2020-01-03'].join("',date='") + "'" }}) AS r
+    retention({{ script: "date='" + ${dates}.join("',date='") + "'" }}) AS r
 FROM retention_test
-WHERE date IN ({{ script: "'" + ['2020-01-03','2020-01-02','2020-01-01'].join("','") + "'" }})
+WHERE date IN ({{ script: "'" + ${dates}.join("','") + "'" }})
 GROUP BY uid
 ORDER BY uid ASC
 ```
@@ -67,10 +68,10 @@ select {{ script: ${num} - 2 }} one,
 <td>
 
 ```sql
-{% var: func=toYear, sdate=2023-01-01 %}
+{% var: func=toYear, sdate='2023-01-01' %}
 SELECT ${func}(create_date) AS d, count(1) AS c
 FROM my_table
-WHERE create_date >= '${sdate}'
+WHERE create_date >= ${sdate}
 GROUP BY d
 ```
 

--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -189,11 +189,12 @@ public final class Option implements Serializable {
             .of(new String[] { "result.type", "The result type, either string, json or stream.", "string", "json",
                     "stream" });
 
+    public static final Option SERVER_URL = Option.of(new String[] { "server.url", "Server url" });
     public static final Option SERVER_HOST = Option.of(new String[] { "server.host", "Server host" });
     public static final Option SERVER_PORT = Option.of("server.port", "Server port", "8080");
     public static final Option SERVER_BACKLOG = Option.of("server.backlog", "Server backlog", "0");
-    public static final Option SERVER_CONTEXT = Option.of("server.context", "Server web context starts with backslash",
-            "/");
+    public static final Option SERVER_CONTEXT = Option.of("server.context",
+            "Server web context starts and ends with backslash", "/");
 
     public static final Option SSL_CERT = Option.of(new String[] { "ssl.cert",
             "Path to the client SSL/TLS certificate file to use for authenticated requests." });

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -233,12 +233,25 @@ public final class Utils {
     }
 
     /**
-     * Converts given string to key value pairs.
+     * Converts given string to key value pairs. Same as
+     * {@code toKeyValuePairs(str, ',', true)}.
      * 
      * @param str string
      * @return non-null key value pairs
      */
     public static Map<String, String> toKeyValuePairs(String str) {
+        return toKeyValuePairs(str, ',', true);
+    }
+
+    /**
+     * Converts given string to key value paris.
+     *
+     * @param str           string
+     * @param delimiter     delimiter maong key value pairs
+     * @param notUrlEncoded whether the key and value are URL encoded or not
+     * @return non-null key value pairs
+     */
+    public static Map<String, String> toKeyValuePairs(String str, char delimiter, boolean notUrlEncoded) {
         if (str == null || str.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -248,7 +261,7 @@ public final class Utils {
         StringBuilder builder = new StringBuilder();
         for (int i = 0, len = str.length(); i < len; i++) {
             char ch = str.charAt(i);
-            if (ch == '\\' && i + 1 < len) {
+            if (notUrlEncoded && ch == '\\' && i + 1 < len) {
                 ch = str.charAt(++i);
                 builder.append(ch);
                 continue;
@@ -260,9 +273,15 @@ public final class Utils {
                 }
             } else if (ch == '=' && key == null) {
                 key = builder.toString().trim();
+                if (!notUrlEncoded) {
+                    key = decode(key);
+                }
                 builder.setLength(0);
-            } else if (ch == ',' && key != null) {
+            } else if (ch == delimiter && key != null) {
                 String value = builder.toString().trim();
+                if (!notUrlEncoded) {
+                    value = decode(value);
+                }
                 builder.setLength(0);
                 if (!key.isEmpty() && !value.isEmpty()) {
                     map.put(key, value);

--- a/core/src/test/java/io/github/jdbcx/BaseIntegrationTest.java
+++ b/core/src/test/java/io/github/jdbcx/BaseIntegrationTest.java
@@ -56,8 +56,6 @@ public class BaseIntegrationTest {
     private static final String PROXY_SERVICE = "toxiproxy";
     private static final int PROXY_PORT = 8474; // control port
 
-    private static final Option SERVER_URL = Option.of(new String[] { "server.url", "JDBCX server url", "" });
-
     private static final String clickhouseServer;
     private static final String postgresqlServer;
     private static final String proxyServer;
@@ -78,7 +76,8 @@ public class BaseIntegrationTest {
                 POSTGRESQL_SERVER.getEffectiveDefaultValue(Constants.EMPTY_STRING));
         proxyServer = PROXY_SERVER.getValue(props, PROXY_SERVER.getEffectiveDefaultValue(Constants.EMPTY_STRING));
 
-        String url = SERVER_URL.getValue(props, SERVER_URL.getEffectiveDefaultValue(Constants.EMPTY_STRING));
+        String url = Option.SERVER_URL.getValue(props,
+                Option.SERVER_URL.getEffectiveDefaultValue(Constants.EMPTY_STRING));
         if (Checker.isNullOrEmpty(url)) {
             // https://java.testcontainers.org/features/networking/#exposing-host-ports-to-the-container?
             try {

--- a/core/src/test/java/io/github/jdbcx/UtilsTest.java
+++ b/core/src/test/java/io/github/jdbcx/UtilsTest.java
@@ -148,6 +148,16 @@ public class UtilsTest {
         Assert.assertEquals(Utils.toKeyValuePairs("Content-Type=application/json,Authorization=Bear 1234 5"), expected);
         Assert.assertEquals(Utils.toKeyValuePairs("Content-Type = application/json , Authorization = Bear 1234 5 "),
                 expected);
+
+        expected.clear();
+        expected.put("a 1", "b ");
+        expected.put("c", "3");
+        Assert.assertEquals(Utils.toKeyValuePairs("a%201=b%20&c=3", '&', false), expected);
+
+        expected.clear();
+        expected.put("a%201", "b%20");
+        expected.put("c", "3");
+        Assert.assertEquals(Utils.toKeyValuePairs("a%201=b%20&c=3", '&', true), expected);
     }
 
     @Test(groups = { "unit" })

--- a/core/src/test/java/io/github/jdbcx/interpreter/VarInterpreterTest.java
+++ b/core/src/test/java/io/github/jdbcx/interpreter/VarInterpreterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.interpreter;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.QueryContext;
+
+public class VarInterpreterTest {
+    @Test(groups = { "unit" })
+    public void testInterpret() {
+        QueryContext context = QueryContext.newContext();
+        Properties config = new Properties();
+
+        VarInterpreter interpreter = new VarInterpreter(context, config);
+        Assert.assertEquals(interpreter.defaultDelimiter, VarInterpreter.OPTION_DELIMITER.getDefaultValue().charAt(0));
+        Assert.assertEquals(interpreter.defaultPrefix, VarInterpreter.OPTION_PREFIX.getDefaultValue());
+
+        config.put(VarInterpreter.OPTION_DELIMITER.getName(), ";");
+        interpreter = new VarInterpreter(context, config);
+        Assert.assertEquals(interpreter.defaultDelimiter, ';');
+        Assert.assertEquals(interpreter.defaultPrefix, VarInterpreter.OPTION_PREFIX.getDefaultValue());
+
+        config.put(VarInterpreter.OPTION_PREFIX.getName(), "Prefix_");
+        interpreter = new VarInterpreter(context, config);
+        Assert.assertEquals(interpreter.defaultDelimiter, ';');
+        Assert.assertEquals(interpreter.defaultPrefix, "Prefix_");
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
@@ -64,6 +64,16 @@ public final class ExecutableBlock {
         return content;
     }
 
+    public boolean sameAs(ExecutableBlock block) {
+        if (this == block) {
+            return true;
+        } else if (block == null) {
+            return false;
+        }
+
+        return output == block.output && extension.equals(block.extension) && content.equals(block.content);
+    }
+
     public boolean hasNoArguments() {
         return props.isEmpty() && Checker.isNullOrBlank(content, true);
     }

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
@@ -417,17 +417,29 @@ public final class QueryParser {
                 if (nextChar == ch && !escaped) { // executable block with output: {{ ... }}
                     int index = indexOf(query, i + 1, "}}", escapeChar);
                     if (index > 0) {
+                        int endIndex = index;
                         for (int k = index; k < len; k++) { // be greedy
                             if (query.charAt(k) == '}') {
                                 index++;
+                                endIndex = index - 2;
                             } else {
                                 break;
+                            }
+                        }
+                        if (endIndex == index) {
+                            endIndex -= 2;
+                            for (int k = endIndex - 1; k > i; k--) {
+                                if (Character.isWhitespace(query.charAt(k))) {
+                                    endIndex = k;
+                                } else {
+                                    break;
+                                }
                             }
                         }
                         if (query.charAt(i + 1) == '-') {
                             log.debug("Skip executable block: %s", query.substring(i - 1, index));
                         } else {
-                            addExecutableBlock(builder, query.substring(i + 1, index - 2), vars, true, parts, blocks);
+                            addExecutableBlock(builder, query.substring(i + 1, endIndex), vars, true, parts, blocks);
                         }
                         i = index - 1;
                     } else {
@@ -436,11 +448,30 @@ public final class QueryParser {
                     }
                 } else if (nextChar == '%' && !escaped) { // executable block: {% ... %}
                     int index = indexOf(query, i + 1, "%}", escapeChar);
+                    int endIndex = index;
+                    for (int k = index; k < len; k++) { // be greedy
+                        if (query.charAt(k) == '%') {
+                            index++;
+                            endIndex = index - 2;
+                        } else {
+                            break;
+                        }
+                    }
+                    if (endIndex == index) {
+                        endIndex -= 2;
+                        for (int k = endIndex - 1; k > i; k--) {
+                            if (Character.isWhitespace(query.charAt(k))) {
+                                endIndex = k;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
                     if (index > 0) {
                         if (query.charAt(i + 1) == '-') {
                             log.debug("Skip executable block: %s", query.substring(i - 1, index));
                         } else {
-                            addExecutableBlock(builder, query.substring(i + 1, index - 2), vars, false, parts, blocks);
+                            addExecutableBlock(builder, query.substring(i + 1, endIndex), vars, false, parts, blocks);
                         }
                         i = index - 1;
                     } else {

--- a/driver/src/main/java/io/github/jdbcx/extension/VarDriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/extension/VarDriverExtension.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import io.github.jdbcx.DriverExtension;
 import io.github.jdbcx.JdbcActivityListener;
+import io.github.jdbcx.Option;
 import io.github.jdbcx.QueryContext;
 import io.github.jdbcx.interpreter.VarInterpreter;
 
@@ -35,6 +36,11 @@ public class VarDriverExtension implements DriverExtension {
     @Override
     public List<String> getAliases() {
         return Collections.singletonList("vars");
+    }
+
+    @Override
+    public List<Option> getDefaultOptions() {
+        return VarInterpreter.OPTIONS;
     }
 
     @Override

--- a/driver/src/test/java/io/github/jdbcx/driver/ExecutableBlockTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/ExecutableBlockTest.java
@@ -23,15 +23,18 @@ import org.testng.annotations.Test;
 public class ExecutableBlockTest {
     @Test(groups = { "unit" })
     public void testConstructor() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ExecutableBlock(0, null, null, null, false));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ExecutableBlock(0, "", null, null, false));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new ExecutableBlock(0, null, null, null, false));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new ExecutableBlock(0, "", null, null, false));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> new ExecutableBlock(0, "", new Properties(), null, false));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> new ExecutableBlock(0, null, new Properties(), null, false));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> new ExecutableBlock(0, null, new Properties(), "", false));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ExecutableBlock(0, null, null, "", false));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new ExecutableBlock(0, null, null, "", false));
 
         ExecutableBlock block = new ExecutableBlock(-1, "ex", new Properties(), "...", true);
         Assert.assertEquals(block, new ExecutableBlock(-1, "ex", new Properties(), "...", true));
@@ -45,5 +48,25 @@ public class ExecutableBlockTest {
         Properties props = new Properties();
         props.setProperty("a", "c");
         Assert.assertEquals(block, new ExecutableBlock(-1, "ex", props, "...", true));
+    }
+
+    @Test(groups = { "unit" })
+    public void testSameAs() {
+        Properties props = new Properties();
+        ExecutableBlock block = new ExecutableBlock(1, "b1", props, "...", true);
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b2", props, "...", true)),
+                "Should be false since extension is different");
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", props, ". .", true)),
+                "Should be false since content is different");
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", props, "...", false)),
+                "Should be false since output is different");
+
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(2, "b1", props, "...", true)),
+                "Should be true because index does not matter");
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", new Properties(), "...", true)),
+                "Should be true because properties do not matter");
+        props.setProperty("a", "b");
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", new Properties(), "...", true)),
+                "Should be true because properties do not matter");
     }
 }

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryBuilderTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryBuilderTest.java
@@ -56,6 +56,14 @@ public class QueryBuilderTest {
                         Arrays.asList("select 1 + 4 as a", "select 2 + 4 as a", "select 3 + 4 as a",
                                 "select 1 + 5 as a", "select 2 + 5 as a", "select 3 + 5 as a"));
             }
+
+            try (WrappedConnection c = (WrappedConnection) conn; QueryContext context = QueryContext.newContext()) {
+                ParsedQuery pq = QueryParser
+                        .parse("select {{ rhino: [1,2] }} + {{ rhino: [3,4,5] }} + {{rhino:[1,2]}}", props);
+                QueryBuilder builder = new QueryBuilder(context, pq, conn.manager, stmt.queryResult);
+                Assert.assertEquals(builder.build(), Arrays.asList("select 1 + 3 + 1", "select 2 + 3 + 2",
+                        "select 1 + 4 + 1", "select 2 + 4 + 2", "select 1 + 5 + 1", "select 2 + 5 + 2"));
+            }
         }
     }
 }

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
@@ -234,10 +234,42 @@ public class QueryParserTest {
         Assert.assertEquals(QueryParser.parse(str = "select 1", props),
                 new ParsedQuery(Arrays.asList(str), Collections.emptyList()));
 
+        Assert.assertEquals(QueryParser.parse("{%var%}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{%var:%}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{% var: %}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{%var: %}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{% var %}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{% var: %}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "", false))));
+        Assert.assertEquals(QueryParser.parse("{% var: a=%%%}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "var", new Properties(), "a=%%", false))));
+
         Assert.assertEquals(QueryParser.parse("{{web}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
+        Assert.assertEquals(QueryParser.parse("{{web:}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
+        Assert.assertEquals(QueryParser.parse("{{ web:}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
+        Assert.assertEquals(QueryParser.parse("{{web: }}", props), new ParsedQuery(Arrays.asList("", ""),
                 Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
         Assert.assertEquals(QueryParser.parse("{{ web }}", props), new ParsedQuery(Arrays.asList("", ""),
                 Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
+        Assert.assertEquals(QueryParser.parse("{{ web: }}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "web", new Properties(), "", true))));
+
+        Assert.assertEquals(QueryParser.parse("{{script:1+1}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "script", new Properties(), "1+1", true))));
+        Assert.assertEquals(QueryParser.parse("{{ script: 1+1 }}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "script", new Properties(), "1+1", true))));
+        Assert.assertEquals(QueryParser.parse("{{ script: {1+1}}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "script", new Properties(), "{1+1}", true))));
+        Assert.assertEquals(QueryParser.parse("{{ script: {1+1}\n}}", props), new ParsedQuery(Arrays.asList("", ""),
+                Arrays.asList(new ExecutableBlock(1, "script", new Properties(), "{1+1}", true))));
 
         Assert.assertEquals(
                 QueryParser.parse(
@@ -277,7 +309,7 @@ public class QueryParserTest {
                 new ParsedQuery(Arrays.asList("select ", "", " from ", ""),
                         Arrays.asList(
                                 new ExecutableBlock(1, "script", new Properties(), "helper.format('%s', '*')", true),
-                                new ExecutableBlock(3, "shell", new Properties(), "echo 'mytable' ", false))));
+                                new ExecutableBlock(3, "shell", new Properties(), "echo 'mytable'", false))));
     }
 
     @Test(groups = { "unit" })
@@ -304,7 +336,7 @@ public class QueryParserTest {
                 new ParsedQuery(Arrays.asList("", ""), Arrays.asList(new ExecutableBlock(1, "web", props, "", true))));
         Assert.assertEquals(QueryParser.parse(str = "{{  web. (   ) :  request body }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "web", props, "request body ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "web", props, "request body", true))));
 
         Properties expectedProps = new Properties();
         Option.ID.setValue(expectedProps, "ch-dev");
@@ -313,21 +345,21 @@ public class QueryParserTest {
                         Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "", true))));
         Assert.assertEquals(QueryParser.parse(str = "{{ web. (id = ch-dev): request }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "request ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "request", true))));
         Assert.assertEquals(QueryParser.parse(str = "{{ web.ch-dev }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
                         Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "", true))));
         Assert.assertEquals(QueryParser.parse(str = "{{ web.ch-dev: my request }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request", true))));
         Assert.assertEquals(QueryParser.parse(str = "{{ web.ch-dev1 (id=ch-dev): my request }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request", true))));
 
         Option.ID.setValue(expectedProps, "$");
         Assert.assertEquals(QueryParser.parse(str = "{{ web.$: my request }}", props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "web", expectedProps, "my request", true))));
         Option.ID.setValue(expectedProps, "${}");
         Assert.assertEquals(QueryParser.parse(str = "{{ web.${}}}", props),
                 new ParsedQuery(Arrays.asList("", ""),
@@ -347,8 +379,8 @@ public class QueryParserTest {
         Option.ID.setValue(expectedProps, "${x}");
         Assert.assertEquals(QueryParser.parse(str = "{% var: x=ch-dev %}{{ web.${x}: my request }}", props),
                 new ParsedQuery(Arrays.asList("", "", "", ""),
-                        Arrays.asList(new ExecutableBlock(1, "var", props, "x=ch-dev ", false),
-                                new ExecutableBlock(3, "web", expectedProps, "my request ", true))));
+                        Arrays.asList(new ExecutableBlock(1, "var", props, "x=ch-dev", false),
+                                new ExecutableBlock(3, "web", expectedProps, "my request", true))));
     }
 
     @Test(groups = { "unit" })


### PR DESCRIPTION
1. customizable delimiter of `var` extension
  ```sql
  -- before
  {% var: arr=[1\,2\,3] %} -- escaping is required because the default delimiter is comma
  -- after
  {% var(delimiter=;): arr=[1,2,3] %}
  ```

2. reuse results for same expression
  ```sql
  -- before
  select {{ script: [1,2] }} a, {{ script: [1,2] }} b -- 4 queries
  a    b
  1    1
  2    1
  1    2
  2    2
  -- after
  select {{ script: [1,2] }} as col{{ script: [1,2] }} -- 2 queries
  a    b
  1    1
  2    2
  ```

3. put them together
  ```sql
  -- assume we have 3 nodes in each of the two datacenters
  -- this will generate 6 queries, each will pull the most recent row from system.text_log
  {% var(delimiter=;): dc=['dc1', 'dc2'] %}
  select '{{ script: ${dc} }}-' || hostName() server, *
  -- here <dc>_node<num> is a pre-defined named collection pointing to the specific server
  from remote({{ script: ${dc} }}_node{{ script: [1,2,3] }}, db='system', table='text_log')
  order by event_time desc
  limit 1
  ```