### PR TITLE
add mapper and passing context from client to bridge server

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Compression.java
+++ b/core/src/main/java/io/github/jdbcx/Compression.java
@@ -15,9 +15,6 @@
  */
 package io.github.jdbcx;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Locale;
 
 import io.github.jdbcx.compress.BrotliSupport;
@@ -79,26 +76,13 @@ public enum Compression {
     }
 
     /**
-     * Checks if the provide for this compression algorithm is available or not.
+     * Gets provider for this compression algorithm.
+     *
+     * @return non-null provider for compressing and decompressing
+     * @throws NoClassDefFoundError when corresponding lib is missing
      */
-    public void checkProvider() {
-        Compression.getProvider(this);
-    }
-
-    public OutputStream compress(OutputStream output) throws IOException {
-        return compress(output, 0, -1);
-    }
-
-    public OutputStream compress(OutputStream output, int level, int bufferSize) throws IOException {
-        return getProvider(this).compress(output, level, bufferSize);
-    }
-
-    public InputStream decompress(InputStream input) throws IOException {
-        return decompress(input, 0, -1);
-    }
-
-    public InputStream decompress(InputStream input, int level, int bufferSize) throws IOException {
-        return getProvider(this).decompress(input, level, bufferSize);
+    public CompressionProvider provider() throws NoClassDefFoundError {
+        return Compression.getProvider(this);
     }
 
     static CompressionProvider getProvider(Compression compress) {
@@ -251,9 +235,9 @@ public enum Compression {
     public static Compression fromMagicNumber(byte[] bytes) {
         Compression compression = null;
 
-        int len = bytes != null ? bytes.length : 0;
-        if (len > 0) {
-            outer_loop: for (Compression c : values()) {// NOSONAR
+        final int len;
+        if (bytes != null && (len = bytes.length) > 0) {
+            outer_loop: for (Compression c : values()) { // NOSONAR
                 if (!c.hasMagicNumber()) {
                     continue;
                 }

--- a/core/src/main/java/io/github/jdbcx/CompressionProvider.java
+++ b/core/src/main/java/io/github/jdbcx/CompressionProvider.java
@@ -33,6 +33,10 @@ public interface CompressionProvider {
         return !Boolean.parseBoolean(OPTION_USE_DEFAULT.getEffectiveDefaultValue(Option.PROPERTY_PREFIX));
     }
 
+    default OutputStream compress(OutputStream output) throws IOException {
+        return compress(output, -1, 0);
+    }
+
     /**
      * Compresses data into the output stream.
      *

--- a/core/src/main/java/io/github/jdbcx/Field.java
+++ b/core/src/main/java/io/github/jdbcx/Field.java
@@ -125,13 +125,21 @@ public final class Field implements Serializable {
             case TIME:
             case TIME_WITH_TIMEZONE:
                 this.precision = precision > 0 ? precision : 10;
-                this.scale = 0;
+                this.scale = scale > 0 ? scale : 0;
                 this.signed = false;
                 break;
             case TIMESTAMP:
             case TIMESTAMP_WITH_TIMEZONE:
                 this.precision = precision > 0 ? precision : 29;
                 this.scale = scale > 0 ? scale : 0;
+                this.signed = false;
+                break;
+            case CHAR:
+            case NCHAR:
+            case VARCHAR:
+            case NVARCHAR:
+                this.precision = precision > 0 ? precision : 0;
+                this.scale = 0;
                 this.signed = false;
                 break;
             default:

--- a/core/src/main/java/io/github/jdbcx/LogMessage.java
+++ b/core/src/main/java/io/github/jdbcx/LogMessage.java
@@ -35,8 +35,8 @@ public final class LogMessage {
         String message = String.valueOf(format);
         Throwable t = null;
 
-        int len = arguments != null ? arguments.length : 0;
-        if (len > 0) {
+        final int len;
+        if (arguments != null && (len = arguments.length) > 0) {
             Object lastArg = arguments[len - 1];
             if (lastArg instanceof Throwable) {
                 t = (Throwable) lastArg;

--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -189,12 +189,17 @@ public final class Option implements Serializable {
             .of(new String[] { "result.type", "The result type, either string, json or stream.", "string", "json",
                     "stream" });
 
+    public static final Option SERVER_AUTH = Option.of(new String[] { "server.auth",
+            "Whether to enable server-side authentication, which requires bearer token for submitting query for execution",
+            Constants.FALSE_EXPR, Constants.TRUE_EXPR });
     public static final Option SERVER_URL = Option
             .of(new String[] { "server.url", "Bridge server URL used for executing the query remotely." });
     public static final Option SERVER_HOST = Option.of(new String[] { "server.host", "Bridge server host." });
     public static final Option SERVER_PORT = Option.of("server.port", "Bridge server port.", "8080");
     public static final Option SERVER_CONTEXT = Option.of("server.context",
             "Server web context starts and ends with backslash", "/");
+    public static final Option SERVER_TOKEN = Option.of(new String[] { "server.token",
+            "Token required to access bridge server with authentication and authorization enabled." });
 
     public static final Option SSL_CERT = Option.of(new String[] { "ssl.cert",
             "Path to the client SSL/TLS certificate file to use for authenticated requests." });

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -62,7 +62,7 @@ import java.util.function.UnaryOperator;
  */
 public final class Utils {
     private static <T> T findFirstService(Class<? extends T> serviceInterface, boolean preferCustomImpl) {
-        Checker.nonNull(serviceInterface, "serviceInterface");
+        Checker.nonNull(serviceInterface, Class.class);
 
         String className = Utils.class.getName();
         String packageName = className.substring(0, className.lastIndexOf('.') + 1);

--- a/core/src/main/java/io/github/jdbcx/cache/CaffeineCache.java
+++ b/core/src/main/java/io/github/jdbcx/cache/CaffeineCache.java
@@ -82,6 +82,6 @@ public class CaffeineCache<K, V> implements Cache<K, V>, RemovalListener<K, V> {
 
     @Override
     public <T> T unwrap(Class<T> clazz) {
-        return Checker.nonNull(clazz, Class.class.getName()).cast(cache);
+        return Checker.nonNull(clazz, Class.class).cast(cache);
     }
 }

--- a/core/src/main/java/io/github/jdbcx/cache/JdkLruCache.java
+++ b/core/src/main/java/io/github/jdbcx/cache/JdkLruCache.java
@@ -90,6 +90,6 @@ public class JdkLruCache<K, V> implements Cache<K, V> {
 
     @Override
     public <T> T unwrap(Class<T> clazz) {
-        return Checker.nonNull(clazz, Class.class.getName()).cast(cache);
+        return Checker.nonNull(clazz, Class.class).cast(cache);
     }
 }

--- a/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
@@ -58,6 +58,7 @@ public class WebExecutor extends AbstractExecutor {
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String HEADER_USER_AGENT = "User-Agent";
+    public static final String HEADER_QUERY_USER = "X-Query-User";
 
     public static final Option OPTION_CONNECT_TIMEOUT = Option
             .of(new String[] { "connect.timeout",

--- a/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
@@ -55,9 +55,13 @@ public class WebExecutor extends AbstractExecutor {
 
     static final String DEFAULT_USER_AGENT = "JDBCX/" + Version.current().toShortString();
 
+    public static final String AUTH_SCHEME_BASIC = "Basic ";
+    public static final String AUTH_SCHEME_BEARER = "Bearer ";
+
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String HEADER_USER_AGENT = "User-Agent";
+    public static final String HEADER_QUERY_MODE = "X-Query-Mode";
     public static final String HEADER_QUERY_USER = "X-Query-User";
 
     public static final Option OPTION_CONNECT_TIMEOUT = Option

--- a/core/src/main/java/io/github/jdbcx/interpreter/WebInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/WebInterpreter.java
@@ -44,10 +44,6 @@ import io.github.jdbcx.executor.Stream;
 import io.github.jdbcx.executor.WebExecutor;
 
 public class WebInterpreter extends AbstractInterpreter {
-    static final String HEADER_AUTHORIZATION = "Authorization";
-    static final String AUTH_SCHEME_BASIC = "Basic ";
-    static final String AUTH_SCHEME_BEARER = "Bearer ";
-
     public static final String KEY_HEADERS = "headers";
 
     public static final Option OPTION_BASE_URL = Option
@@ -91,14 +87,14 @@ public class WebInterpreter extends AbstractInterpreter {
     static final Map<String, String> getHeaders(VariableTag tag, Properties config) {
         Map<String, String> headers = new HashMap<>(Utils
                 .toKeyValuePairs(Utils.applyVariables(OPTION_REQUEST_HEADERS.getValue(config), tag, config)));
-        String secret = Utils.applyVariables(OPTION_AUTH_BEARER_TOKEN.getValue(config), tag, config);
-        if (!Checker.isNullOrBlank(secret)) { // recommended
-            headers.put(HEADER_AUTHORIZATION, AUTH_SCHEME_BEARER.concat(secret));
+        String token = Utils.applyVariables(OPTION_AUTH_BEARER_TOKEN.getValue(config), tag, config);
+        if (!Checker.isNullOrBlank(token)) { // recommended
+            headers.put(WebExecutor.HEADER_AUTHORIZATION, WebExecutor.AUTH_SCHEME_BEARER.concat(token));
         } else { // less secure
-            secret = OPTION_AUTH_BASIC_USER.getValue(config);
-            if (!Checker.isNullOrBlank(secret)) {
-                headers.put(HEADER_AUTHORIZATION, AUTH_SCHEME_BASIC.concat(Base64.getEncoder()
-                        .encodeToString(new StringBuilder(secret).append(':')
+            token = OPTION_AUTH_BASIC_USER.getValue(config);
+            if (!Checker.isNullOrBlank(token)) {
+                headers.put(WebExecutor.HEADER_AUTHORIZATION, WebExecutor.AUTH_SCHEME_BASIC.concat(Base64.getEncoder()
+                        .encodeToString(new StringBuilder(token).append(':')
                                 .append(OPTION_AUTH_BASIC_PASSWORD.getValue(config)).toString()
                                 .getBytes(Constants.DEFAULT_CHARSET))));
             }

--- a/core/src/test/java/io/github/jdbcx/CompressionTest.java
+++ b/core/src/test/java/io/github/jdbcx/CompressionTest.java
@@ -110,7 +110,7 @@ public class CompressionTest {
             int bufferSize = 0;
             int level = -1;
             try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-                    OutputStream compressedOut = c.compress(out, bufferSize, level)) {
+                    OutputStream compressedOut = c.provider().compress(out, bufferSize, level)) {
                 compressedOut.write(new byte[] { 1, 2, 3 });
                 compressedOut.close();
                 bytes = out.toByteArray();
@@ -123,7 +123,7 @@ public class CompressionTest {
             }
 
             try (ByteArrayInputStream in = new ByteArrayInputStream(bytes);
-                    InputStream decompressedIn = c.decompress(in, bufferSize, level)) {
+                    InputStream decompressedIn = c.provider().decompress(in, bufferSize, level)) {
                 Assert.assertEquals(decompressedIn.read(), 1);
                 Assert.assertEquals(decompressedIn.read(), 2);
                 Assert.assertEquals(decompressedIn.read(), 3);

--- a/core/src/test/java/io/github/jdbcx/ResultTest.java
+++ b/core/src/test/java/io/github/jdbcx/ResultTest.java
@@ -197,4 +197,42 @@ public class ResultTest {
         Assert.assertEquals(r.type(), DefaultRow.class);
         Assert.assertEquals(r.get(String.class), "a");
     }
+
+    @Test(groups = "unit")
+    public void testActive() {
+        Result<?> result = Result.of("123");
+        Assert.assertFalse(result.isActive());
+        Assert.assertEquals(result.fields(), Collections.singletonList(Field.DEFAULT));
+        Assert.assertFalse(result.isActive());
+        Assert.assertEquals(result.get(), "123");
+        Assert.assertTrue(result.isActive());
+        result.close();
+        Assert.assertFalse(result.isActive());
+        Assert.assertEquals(result.get(), "123");
+        Assert.assertTrue(result.isActive());
+
+        try (Result<?> r = result.update().build()) {
+            Assert.assertTrue(result.isActive());
+            Assert.assertFalse(r.isActive());
+            Assert.assertEquals(r.get(String.class), "123");
+            Assert.assertTrue(r.isActive());
+            Assert.assertTrue(result.isActive());
+        }
+
+        try (Result<?> r = result.update().build()) {
+            Assert.assertTrue(result.isActive());
+            Assert.assertFalse(r.isActive());
+            Assert.assertEquals(r.get(String.class, new ErrorHandler("321")), "123");
+            Assert.assertTrue(r.isActive());
+            Assert.assertTrue(result.isActive());
+        }
+
+        try (Result<?> r = result.update().build()) {
+            Assert.assertTrue(result.isActive());
+            Assert.assertFalse(r.isActive());
+            Assert.assertNotNull(r.rows());
+            Assert.assertTrue(r.isActive());
+            Assert.assertTrue(result.isActive());
+        }
+    }
 }

--- a/docker/app/.jdbcx/config.properties
+++ b/docker/app/.jdbcx/config.properties
@@ -8,7 +8,14 @@ jdbcx.custom.classpath=/app/drivers
 #
 jdbcx.prql.cli.path=/usr/bin/prqlc
 jdbcx.prql.compile.options=--hide-signature-comment,--no-format
+# start the bridge server on myserver first, for instance:
+# docker run --rm -it -p8080:8080 jdbcx/jdbcx server
+#jdbcx.server.url=http://myserver:8080/
 
 #
 # server options
 #
+#jdbcx.server.host=0.0.0.0
+#jdbcx.server.port=8080
+#jdbcx.server.auth=false
+#jdbcx.server.token=

--- a/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
@@ -17,7 +17,6 @@ package io.github.jdbcx;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.List;
 
 public interface JdbcDialect {
     default VariableTag getVariableTag() {
@@ -28,13 +27,7 @@ public interface JdbcDialect {
         return ValueFactory.getInstance();
     }
 
-    default String union(List<String> queries) {
-        return String.join("\nunion all\n", queries);
-    }
-
     ResultMapper getMapper();
-
-    void createTemporaryTable(String table, Field... fields) throws SQLException;
 
     /**
      * Gets table representing the given URL. This is typically used in a query like

--- a/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
@@ -32,6 +32,8 @@ public interface JdbcDialect {
         return String.join("\nunion all\n", queries);
     }
 
+    ResultMapper getMapper();
+
     void createTemporaryTable(String table, Field... fields) throws SQLException;
 
     /**

--- a/driver/src/main/java/io/github/jdbcx/QueryMode.java
+++ b/driver/src/main/java/io/github/jdbcx/QueryMode.java
@@ -13,13 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jdbcx.server;
+package io.github.jdbcx;
+
+import java.util.Locale;
 
 public enum QueryMode {
-    SUBMIT_QUERY("s"), // submit query without execution
-    SUBMIT_REDIRECT("r"), // submit query and redirect
-    ASYNC_QUERY("a"),
-    DIRECT_QUERY("d"), // execute query
+    /**
+     * Submits the query for execution later.
+     */
+    SUBMIT("s"),
+    /**
+     * Submits the query and expects a redirect to the URL for retrieving results.
+     */
+    REDIRECT("r"),
+    /**
+     * Executes the query asynchronously immediately.
+     */
+    ASYNC("a"),
+    /**
+     * Executes the query and waits the result.
+     */
+    DIRECT("d"), // execute query
+    /**
+     * Executes a mutation and waits for the result.
+     */
     MUTATION("m"); // mutation
 
     private String code;
@@ -35,24 +52,24 @@ public enum QueryMode {
     public static QueryMode of(String str) {
         QueryMode mode = null;
         if (str == null || str.isEmpty()) {
-            mode = SUBMIT_QUERY;
+            mode = SUBMIT;
         } else if (str.length() == 1) {
             switch (str.charAt(0)) {
                 case 'a':
                 case 'A':
-                    mode = ASYNC_QUERY;
+                    mode = ASYNC;
                     break;
                 case 's':
                 case 'S':
-                    mode = SUBMIT_QUERY;
+                    mode = SUBMIT;
                     break;
                 case 'r':
                 case 'R':
-                    mode = SUBMIT_REDIRECT;
+                    mode = REDIRECT;
                     break;
                 case 'd':
                 case 'D':
-                    mode = DIRECT_QUERY;
+                    mode = DIRECT;
                     break;
                 case 'm':
                 case 'M':
@@ -61,6 +78,8 @@ public enum QueryMode {
                 default:
                     break;
             }
+        } else {
+            mode = valueOf(str.toUpperCase(Locale.ROOT));
         }
         if (mode == null) {
             throw new IllegalArgumentException("Unsupported query mode: " + str);

--- a/driver/src/main/java/io/github/jdbcx/ResultMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/ResultMapper.java
@@ -16,6 +16,10 @@
 package io.github.jdbcx;
 
 public interface ResultMapper {
+    default String quoteIdentifier(String name) {
+        return new StringBuilder().append('"').append(Utils.escape(name, '"', '"')).append('"').toString();
+    }
+
     String toColumnType(Field f);
 
     default String toColumnDefinition(Field... fields) {
@@ -25,20 +29,16 @@ public interface ResultMapper {
         }
 
         Field f = fields[0];
-        char quote = '`';
-        char escape = '\\';
         StringBuilder builder = new StringBuilder();
-        builder.append(quote).append(Utils.escape(f.name(), quote, escape)).append(quote).append(' ')
-                .append(toColumnType(f));
+        builder.append(quoteIdentifier(f.name())).append(' ').append(toColumnType(f));
         for (int i = 1; i < len; i++) {
             f = fields[i];
-            builder.append(',').append(quote).append(Utils.escape(f.name(), quote, escape)).append(quote).append(' ')
-                    .append(toColumnType(f));
+            builder.append(',').append(quoteIdentifier(f.name())).append(' ').append(toColumnType(f));
         }
         return builder.toString();
     }
 
     default String toRemoteTable(String url, Format format, Compression compress, Result<?> result) {
-        return url;
+        return new StringBuilder((url != null ? url.length() : 4) + 2).append('\'').append(url).append('\'').toString();
     }
 }

--- a/driver/src/main/java/io/github/jdbcx/ResultMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/ResultMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+public interface ResultMapper {
+    String toColumnType(Field f);
+
+    default String toColumnDefinition(Field... fields) {
+        final int len;
+        if (fields == null || (len = fields.length) == 0) {
+            return Constants.EMPTY_STRING;
+        }
+
+        Field f = fields[0];
+        char quote = '`';
+        char escape = '\\';
+        StringBuilder builder = new StringBuilder();
+        builder.append(quote).append(Utils.escape(f.name(), quote, escape)).append(quote).append(' ')
+                .append(toColumnType(f));
+        for (int i = 1; i < len; i++) {
+            f = fields[i];
+            builder.append(',').append(quote).append(Utils.escape(f.name(), quote, escape)).append(quote).append(' ')
+                    .append(toColumnType(f));
+        }
+        return builder.toString();
+    }
+
+    default String toRemoteTable(String url, Format format, Compression compress, Result<?> result) {
+        return url;
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseDialect.java
@@ -21,14 +21,8 @@ import io.github.jdbcx.Field;
 import io.github.jdbcx.JdbcDialect;
 import io.github.jdbcx.ResultMapper;
 
-public final class DefaultDialect implements JdbcDialect {
-    private static final JdbcDialect instance = new DefaultDialect();
-
-    static final DefaultMapper mapper = new DefaultMapper();
-
-    public static JdbcDialect getInstance() {
-        return instance;
-    }
+public class ClickHouseDialect implements JdbcDialect {
+    static final ClickHouseMapper mapper = new ClickHouseMapper();
 
     @Override
     public ResultMapper getMapper() {
@@ -39,8 +33,5 @@ public final class DefaultDialect implements JdbcDialect {
     public void createTemporaryTable(String table, Field... fields) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'createTemporaryTable'");
-    }
-
-    private DefaultDialect() {
     }
 }

--- a/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Logger;
+import io.github.jdbcx.LoggerFactory;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.ResultMapper;
+
+public class ClickHouseMapper implements ResultMapper {
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseMapper.class);
+
+    static final String DEFAULT_FORMAT = "CSVWithNames";
+
+    static String toClickHouseDataFormat(Format f) {
+        if (f == null) {
+            return DEFAULT_FORMAT;
+        }
+
+        final String format;
+        switch (f) {
+            case JSONL:
+            case NDJSON:
+                format = "JSONEachLine";
+                break;
+            case TSV:
+                format = "TSVWithNames";
+                break;
+            case CSV:
+            default:
+                format = DEFAULT_FORMAT;
+                break;
+        }
+        return format;
+    }
+
+    @Override
+    public String toColumnType(Field f) {
+        StringBuilder type = new StringBuilder();
+        if (f.isNullable()) {
+            type.append("Nullable(");
+        }
+        switch (f.type()) {
+            case BIT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                if (f.precision() > 128) {
+                    type.append("Int256");
+                } else if (f.precision() > 64) {
+                    type.append("Int128");
+                } else if (f.precision() > 32) {
+                    type.append("Int64");
+                } else if (f.precision() > 16) {
+                    type.append("Int32");
+                } else if (f.precision() > 8) {
+                    type.append("Int16");
+                } else if (f.precision() > 1) {
+                    type.append("Int8");
+                } else {
+                    type.setLength(0);
+                    type.append("Boolean");
+                }
+                break;
+            case CHAR:
+            case NCHAR:
+                type.append("FixedString(").append(f.precision()).append(')');
+                break;
+            case BOOLEAN:
+                type.append("Boolean");
+                break;
+            case TINYINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append("Int8");
+                break;
+            case SMALLINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append("Int16");
+                break;
+            case INTEGER:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append("Int32");
+                break;
+            case BIGINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append("Int64");
+                break;
+            case REAL:
+            case FLOAT:
+                type.append("Float32");
+                break;
+            case DOUBLE:
+                type.append("Float64");
+                break;
+            case NUMERIC:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                if (f.precision() > 39) {
+                    type.append("Int256");
+                } else if (f.precision() > 20) {
+                    type.append("Int128");
+                } else if (f.precision() > 10) {
+                    type.append("Int64");
+                } else if (f.precision() > 5) {
+                    type.append("Int32");
+                } else if (f.precision() > 3) {
+                    type.append("Int16");
+                } else {
+                    type.append("Int8");
+                }
+                break;
+            case DECIMAL:
+                type.append("Decimal(").append(f.precision()).append(',').append(f.scale()).append(')');
+                break;
+            case DATE:
+                type.append("Date32");
+                break;
+            case TIME:
+                type.append("Time");
+                break;
+            case TIMESTAMP:
+            case TIME_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIMEZONE:
+                type.append("DateTime64");
+                break;
+            case VARCHAR:
+            case NVARCHAR:
+            case LONGVARCHAR:
+            case LONGNVARCHAR:
+                type.append("String");
+                break;
+            // case ARRAY:
+            // case OTHER:
+            // case NULL:
+            default:
+                log.warn("Not sure how to map JDBC type [%s], use String instead", f.type());
+                type.append("String");
+                break;
+        }
+        if (f.isNullable()) {
+            type.append(')');
+        }
+        return type.toString();
+    }
+
+    @Override
+    public String toRemoteTable(String url, Format format, Compression compress, Result<?> result) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("url('").append(url).append("',").append(toClickHouseDataFormat(format)).append(",'")
+                .append(toColumnDefinition(result.fields().toArray(new Field[0]))).append("',headers('accept'='")
+                .append(format.mimeType()).append('\'');
+        if (compress != null && compress != Compression.NONE) {
+            builder.append(",'accept-encoding'='").append(compress.encoding()).append('\'');
+        }
+        return builder.append("))").toString();
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
@@ -15,151 +15,192 @@
  */
 package io.github.jdbcx.dialect;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.github.jdbcx.Compression;
+import io.github.jdbcx.Constants;
 import io.github.jdbcx.Field;
 import io.github.jdbcx.Format;
 import io.github.jdbcx.Logger;
 import io.github.jdbcx.LoggerFactory;
 import io.github.jdbcx.Result;
 import io.github.jdbcx.ResultMapper;
+import io.github.jdbcx.Utils;
 
 public class ClickHouseMapper implements ResultMapper {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseMapper.class);
 
-    static final String DEFAULT_FORMAT = "CSVWithNames";
+    static final String FORMAT_CSV = "CSVWithNames";
+    static final String FORMAT_TSV = "TSVWithNames";
+    static final String FORMAT_JSONEACHLINE = "JSONEachLine";
+    static final String FORMAT_LINEASSTRING = "LineAsString";
+
+    static final String TYPE_NULLABLE = "Nullable";
+
+    static final String TYPE_BOOL = "Boolean";
+    static final String TYPE_INT8 = "Int8";
+    static final String TYPE_INT16 = "Int16";
+    static final String TYPE_INT32 = "Int32";
+    static final String TYPE_INT64 = "Int64";
+    static final String TYPE_INT128 = "Int128";
+    static final String TYPE_INT256 = "Int256";
+    static final String TYPE_FLOAT32 = "Float32";
+    static final String TYPE_FLOAT64 = "Float64";
+    static final String TYPE_DECIMAL = "Decimal";
+    static final String TYPE_DATE = "Date";
+    static final String TYPE_DATE32 = "Date32";
+    static final String TYPE_TIME = "Time";
+    static final String TYPE_DATETIME = "DateTime";
+    static final String TYPE_DATETIME64 = "DateTime64";
+    static final String TYPE_FIXEDSTRING = "FixedString";
+    static final String TYPE_STRING = "String";
 
     static String toClickHouseDataFormat(Format f) {
         if (f == null) {
-            return DEFAULT_FORMAT;
+            return FORMAT_CSV;
         }
 
         final String format;
         switch (f) {
             case JSONL:
             case NDJSON:
-                format = "JSONEachLine";
+                format = FORMAT_JSONEACHLINE;
                 break;
             case TSV:
-                format = "TSVWithNames";
+                format = FORMAT_TSV;
                 break;
             case CSV:
             default:
-                format = DEFAULT_FORMAT;
+                format = FORMAT_CSV;
                 break;
         }
         return format;
     }
 
     @Override
+    public String quoteIdentifier(String name) {
+        return new StringBuilder().append('`').append(Utils.escape(name, '`', '\\')).append('`').toString();
+    }
+
+    @Override
     public String toColumnType(Field f) {
         StringBuilder type = new StringBuilder();
         if (f.isNullable()) {
-            type.append("Nullable(");
+            type.append(TYPE_NULLABLE).append('(');
         }
         switch (f.type()) {
             case BIT:
-                if (!f.isSigned()) {
+                if (f.precision() > 1 && !f.isSigned()) {
                     type.append('U');
                 }
                 if (f.precision() > 128) {
-                    type.append("Int256");
+                    type.append(TYPE_INT256);
                 } else if (f.precision() > 64) {
-                    type.append("Int128");
+                    type.append(TYPE_INT128);
                 } else if (f.precision() > 32) {
-                    type.append("Int64");
+                    type.append(TYPE_INT64);
                 } else if (f.precision() > 16) {
-                    type.append("Int32");
+                    type.append(TYPE_INT32);
                 } else if (f.precision() > 8) {
-                    type.append("Int16");
+                    type.append(TYPE_INT16);
                 } else if (f.precision() > 1) {
-                    type.append("Int8");
+                    type.append(TYPE_INT8);
                 } else {
-                    type.setLength(0);
-                    type.append("Boolean");
+                    type.append(TYPE_BOOL);
                 }
                 break;
             case CHAR:
             case NCHAR:
-                type.append("FixedString(").append(f.precision()).append(')');
+                if (f.precision() < 1) {
+                    type.append(TYPE_STRING);
+                } else {
+                    type.append(TYPE_FIXEDSTRING).append('(').append(f.precision()).append(')');
+                }
                 break;
             case BOOLEAN:
-                type.append("Boolean");
+                type.append(TYPE_BOOL);
                 break;
             case TINYINT:
                 if (!f.isSigned()) {
                     type.append('U');
                 }
-                type.append("Int8");
+                type.append(TYPE_INT8);
                 break;
             case SMALLINT:
                 if (!f.isSigned()) {
                     type.append('U');
                 }
-                type.append("Int16");
+                type.append(TYPE_INT16);
                 break;
             case INTEGER:
                 if (!f.isSigned()) {
                     type.append('U');
                 }
-                type.append("Int32");
+                type.append(TYPE_INT32);
                 break;
             case BIGINT:
                 if (!f.isSigned()) {
                     type.append('U');
                 }
-                type.append("Int64");
+                type.append(TYPE_INT64);
                 break;
             case REAL:
             case FLOAT:
-                type.append("Float32");
+                type.append(TYPE_FLOAT32);
                 break;
             case DOUBLE:
-                type.append("Float64");
+                type.append(TYPE_FLOAT64);
                 break;
             case NUMERIC:
                 if (!f.isSigned()) {
                     type.append('U');
                 }
                 if (f.precision() > 39) {
-                    type.append("Int256");
+                    type.append(TYPE_INT256);
                 } else if (f.precision() > 20) {
-                    type.append("Int128");
+                    type.append(TYPE_INT128);
                 } else if (f.precision() > 10) {
-                    type.append("Int64");
+                    type.append(TYPE_INT64);
                 } else if (f.precision() > 5) {
-                    type.append("Int32");
+                    type.append(TYPE_INT32);
                 } else if (f.precision() > 3) {
-                    type.append("Int16");
+                    type.append(TYPE_INT16);
                 } else {
-                    type.append("Int8");
+                    type.append(TYPE_INT8);
                 }
                 break;
             case DECIMAL:
-                type.append("Decimal(").append(f.precision()).append(',').append(f.scale()).append(')');
+                type.append(TYPE_DECIMAL).append('(').append(f.precision()).append(',').append(f.scale()).append(')');
                 break;
             case DATE:
-                type.append("Date32");
+                type.append(TYPE_DATE32);
                 break;
             case TIME:
-                type.append("Time");
+                type.append(TYPE_TIME);
                 break;
             case TIMESTAMP:
             case TIME_WITH_TIMEZONE:
             case TIMESTAMP_WITH_TIMEZONE:
-                type.append("DateTime64");
+                type.append(TYPE_DATETIME64);
+                if (f.scale() > 0) {
+                    type.append('(')
+                            .append(f.scale() <= Constants.MAX_TIME_SCALE ? f.scale() : Constants.MAX_TIME_SCALE)
+                            .append(')');
+                }
                 break;
             case VARCHAR:
             case NVARCHAR:
             case LONGVARCHAR:
             case LONGNVARCHAR:
-                type.append("String");
+                type.append(TYPE_STRING);
                 break;
             // case ARRAY:
             // case OTHER:
             // case NULL:
             default:
                 log.warn("Not sure how to map JDBC type [%s], use String instead", f.type());
-                type.append("String");
+                type.append(TYPE_STRING);
                 break;
         }
         if (f.isNullable()) {
@@ -170,13 +211,29 @@ public class ClickHouseMapper implements ResultMapper {
 
     @Override
     public String toRemoteTable(String url, Format format, Compression compress, Result<?> result) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("url('").append(url).append("',").append(toClickHouseDataFormat(format)).append(",'")
-                .append(toColumnDefinition(result.fields().toArray(new Field[0]))).append("',headers('accept'='")
-                .append(format.mimeType()).append('\'');
-        if (compress != null && compress != Compression.NONE) {
-            builder.append(",'accept-encoding'='").append(compress.encoding()).append('\'');
+        StringBuilder builder = new StringBuilder().append("url('").append(url).append('\'');
+        if (format == null && result == null && (compress == null || compress == Compression.NONE)) {
+            return builder.append(',').append(FORMAT_LINEASSTRING).append(')').toString();
         }
-        return builder.append("))").toString();
+
+        builder.append(',').append(toClickHouseDataFormat(format));
+        if (result != null) {
+            builder.append(",'")
+                    .append(Utils.escape(toColumnDefinition(result.fields().toArray(new Field[0])), '\'', '\\'))
+                    .append('\'');
+        }
+        List<String> parts = new ArrayList<>(2);
+        if (format != null) {
+            parts.add(new StringBuilder("'accept'='").append(format.mimeType()).append('\'').toString());
+        }
+        if (compress != null && compress != Compression.NONE) {
+            parts.add(new StringBuilder("'accept-encoding'='").append(compress.encoding()).append('\'').toString());
+        }
+        if (parts.isEmpty()) {
+            builder.append(')');
+        } else {
+            builder.append(",headers(").append(String.join(",", parts)).append("))");
+        }
+        return builder.toString();
     }
 }

--- a/driver/src/main/java/io/github/jdbcx/dialect/DefaultDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/DefaultDialect.java
@@ -15,9 +15,6 @@
  */
 package io.github.jdbcx.dialect;
 
-import java.sql.SQLException;
-
-import io.github.jdbcx.Field;
 import io.github.jdbcx.JdbcDialect;
 import io.github.jdbcx.ResultMapper;
 
@@ -33,12 +30,6 @@ public final class DefaultDialect implements JdbcDialect {
     @Override
     public ResultMapper getMapper() {
         return mapper;
-    }
-
-    @Override
-    public void createTemporaryTable(String table, Field... fields) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'createTemporaryTable'");
     }
 
     private DefaultDialect() {

--- a/driver/src/main/java/io/github/jdbcx/dialect/DefaultMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/DefaultMapper.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Logger;
+import io.github.jdbcx.LoggerFactory;
+import io.github.jdbcx.ResultMapper;
+
+public class DefaultMapper implements ResultMapper {
+    private static final Logger log = LoggerFactory.getLogger(DefaultMapper.class);
+
+    @Override
+    public String toColumnType(Field f) {
+        StringBuilder type = new StringBuilder();
+        switch (f.type()) {
+            case BIT:
+                if (f.precision() > 64) {
+                    type.append("DECIMAL(").append(f.precision() / 8 + f.precision() % 8 > 0 ? 1 : 0)
+                            .append(", 0)");
+                } else if (f.precision() > 32) {
+                    type.append("BIGINT");
+                } else if (f.precision() > 16) {
+                    type.append("INT");
+                } else if (f.precision() > 8) {
+                    type.append("SMALLINT");
+                } else {
+                    type.append("TINYINT");
+                }
+                break;
+            case CHAR:
+            case NCHAR:
+                type.append("CHAR(").append(f.precision()).append(')');
+                break;
+            case BOOLEAN:
+            case TINYINT:
+                type.append("TINYINT");
+                break;
+            case SMALLINT:
+                type.append("SMALLINT");
+                break;
+            case INTEGER:
+                type.append("INT");
+                break;
+            case BIGINT:
+                type.append("BIGINT");
+                break;
+            case REAL:
+            case FLOAT:
+                type.append("FLOAT");
+                break;
+            case DOUBLE:
+                type.append("DOUBLE");
+                break;
+            case NUMERIC:
+            case DECIMAL:
+                type.append("DECIMAL(").append(f.precision()).append(',').append(f.scale()).append(')');
+                break;
+            case DATE:
+                type.append("DATE");
+                break;
+            case TIME:
+                type.append("TIME");
+                break;
+            case TIMESTAMP:
+            case TIME_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIMEZONE:
+                type.append("DATETIME");
+                break;
+            case VARCHAR:
+            case NVARCHAR:
+            case LONGVARCHAR:
+            case LONGNVARCHAR:
+                type.append("VARCHAR");
+                if (f.precision() > 0) {
+                    type.append('(').append(f.precision()).append(')');
+                }
+                break;
+            // case ARRAY:
+            // case OTHER:
+            // case NULL:
+            default:
+                log.warn("Not sure how to map JDBC type [%s], use VARCHAR instead", f.type());
+                type.append("VARCHAR");
+                break;
+        }
+        if (f.isNullable()) {
+            type.append(" NULL");
+        } else {
+            type.append(" NOT NULL");
+        }
+        return type.toString();
+    }
+
+    protected DefaultMapper() {
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/dialect/DefaultMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/DefaultMapper.java
@@ -43,7 +43,11 @@ public class DefaultMapper implements ResultMapper {
                 break;
             case CHAR:
             case NCHAR:
-                type.append("CHAR(").append(f.precision()).append(')');
+                if (f.precision() < 1) {
+                    type.append("VARCHAR");
+                } else {
+                    type.append("CHAR(").append(f.precision()).append(')');
+                }
                 break;
             case BOOLEAN:
             case TINYINT:
@@ -53,7 +57,7 @@ public class DefaultMapper implements ResultMapper {
                 type.append("SMALLINT");
                 break;
             case INTEGER:
-                type.append("INT");
+                type.append("INTEGER");
                 break;
             case BIGINT:
                 type.append("BIGINT");
@@ -89,9 +93,6 @@ public class DefaultMapper implements ResultMapper {
                     type.append('(').append(f.precision()).append(')');
                 }
                 break;
-            // case ARRAY:
-            // case OTHER:
-            // case NULL:
             default:
                 log.warn("Not sure how to map JDBC type [%s], use VARCHAR instead", f.type());
                 type.append("VARCHAR");

--- a/driver/src/main/java/io/github/jdbcx/dialect/DuckDBDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/DuckDBDialect.java
@@ -18,8 +18,8 @@ package io.github.jdbcx.dialect;
 import io.github.jdbcx.JdbcDialect;
 import io.github.jdbcx.ResultMapper;
 
-public class ClickHouseDialect implements JdbcDialect {
-    static final ClickHouseMapper mapper = new ClickHouseMapper();
+public class DuckDBDialect implements JdbcDialect {
+    static final DuckDBMapper mapper = new DuckDBMapper();
 
     @Override
     public ResultMapper getMapper() {

--- a/driver/src/main/java/io/github/jdbcx/dialect/DuckDBMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/DuckDBMapper.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Logger;
+import io.github.jdbcx.LoggerFactory;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.ResultMapper;
+
+public class DuckDBMapper implements ResultMapper {
+    private static final Logger log = LoggerFactory.getLogger(DuckDBMapper.class);
+
+    static final String FUNC_READ_CSV = "read_csv_auto";
+    static final String FUNC_READ_JSON = "read_json_auto";
+
+    // https://duckdb.org/docs/sql/data_types/overview.html
+    static final String TYPE_BOOLEAN = "BOOLEAN"; // logical boolean (true/false)
+    static final String TYPE_TINYINT = "TINYINT"; // signed one-byte integer
+    static final String TYPE_SMALLINT = "SMALLINT"; // signed two-byte integer
+    static final String TYPE_INTEGER = "INTEGER"; // signed four-byte integer
+    static final String TYPE_BIGINT = "BIGINT"; // signed eight-byte integer
+    static final String TYPE_HUGEINT = "HUGEINT"; // signed sixteen-byte integer
+    static final String TYPE_REAL = "REAL"; // single precision floating-point number (4 bytes)
+    static final String TYPE_DOUBLE = "DOUBLE"; // double precision floating-point number (8 bytes)
+    static final String TYPE_DECIMAL = "DECIMAL"; // fixed-precision number with the given width (precision) and scale,
+                                                  // defaults to prec = 18 and scale = 3
+
+    static final String TYPE_INTERVAL = "INTERVAL"; // date / time delta
+    static final String TYPE_DATE = "DATE"; // calendar date (year, month day)
+    static final String TYPE_TIME = "TIME"; // time of day (ignores time zone)
+    static final String TYPE_TIMETZ = "TIMETZ"; // time of day (uses time zone)
+    static final String TYPE_TIMESTAMP = "TIMESTAMP"; // timestamp with nanosecond precision (ignores time zone)
+    static final String TYPE_TIMESTAMPTZ = "TIMESTAMPTZ"; // timestamp (uses time zone)
+
+    static final String TYPE_BIT = "BIT"; // string of 1s and 0s
+    static final String TYPE_BLOB = "BLOB"; // variable-length binary data
+    static final String TYPE_UUID = "UUID"; // UUID data type
+    static final String TYPE_VARCHAR = "VARCHAR"; // variable-length character string
+
+    static final String SUFFIX_SEC = "_S";
+    static final String SUFFIX_MS = "_MS";
+    static final String SUFFIX_NS = "_NS";
+
+    protected String toStructDefinition(Field... fields) {
+        final int len;
+        if (fields == null || (len = fields.length) == 0) {
+            return new String(new char[] { '{', '}' });
+        }
+
+        StringBuilder builder = new StringBuilder().append('{');
+        Field f = fields[0];
+        builder.append(quoteIdentifier(f.name())).append(':').append('\'').append(toColumnType(f)).append('\'');
+        for (int i = 1; i < len; i++) {
+            f = fields[i];
+            builder.append(',').append(quoteIdentifier(f.name())).append(':').append('\'').append(toColumnType(f))
+                    .append('\'');
+        }
+        return builder.append('}').toString();
+    }
+
+    @Override
+    public String toColumnType(Field f) {
+        StringBuilder type = new StringBuilder();
+        switch (f.type()) {
+            case BIT:
+                if (f.precision() > 1 && !f.isSigned()) {
+                    type.append('U');
+                }
+                if (f.precision() > 64) {
+                    type.append(TYPE_HUGEINT);
+                } else if (f.precision() > 32) {
+                    type.append(TYPE_BIGINT);
+                } else if (f.precision() > 16) {
+                    type.append(TYPE_INTEGER);
+                } else if (f.precision() > 8) {
+                    type.append(TYPE_SMALLINT);
+                } else if (f.precision() > 1) {
+                    type.append(TYPE_TINYINT);
+                } else {
+                    type.append(TYPE_BOOLEAN);
+                }
+                break;
+            case BOOLEAN:
+                type.append(TYPE_BOOLEAN);
+                break;
+            case TINYINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append(TYPE_TINYINT);
+                break;
+            case SMALLINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append(TYPE_SMALLINT);
+                break;
+            case INTEGER:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append(TYPE_INTEGER);
+                break;
+            case BIGINT:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                type.append(TYPE_BIGINT);
+                break;
+            case REAL:
+            case FLOAT:
+                type.append(TYPE_REAL);
+                break;
+            case DOUBLE:
+                type.append(TYPE_DOUBLE);
+                break;
+            case NUMERIC:
+                if (!f.isSigned()) {
+                    type.append('U');
+                }
+                if (f.precision() > 20) {
+                    type.append(TYPE_HUGEINT);
+                } else if (f.precision() > 10) {
+                    type.append(TYPE_BIGINT);
+                } else if (f.precision() > 5) {
+                    type.append(TYPE_INTEGER);
+                } else if (f.precision() > 3) {
+                    type.append(TYPE_SMALLINT);
+                } else {
+                    type.append(TYPE_TINYINT);
+                }
+                break;
+            case DECIMAL:
+                type.append(TYPE_DECIMAL).append('(').append(f.precision()).append(',').append(f.scale()).append(')');
+                break;
+            case DATE:
+                type.append(TYPE_DATE);
+                break;
+            case TIME:
+                type.append(TYPE_TIME);
+                break;
+            case TIME_WITH_TIMEZONE:
+                type.append(TYPE_TIMETZ);
+                break;
+            case TIMESTAMP:
+                type.append(TYPE_TIMESTAMP);
+                if (f.scale() > 6) {
+                    type.append(SUFFIX_NS); // nanosecond
+                } else if (f.scale() > 0) {
+                    type.append(SUFFIX_MS); // millisecond
+                } else {
+                    type.append(SUFFIX_SEC); // second
+                }
+                break;
+            case TIMESTAMP_WITH_TIMEZONE:
+                type.append(TYPE_TIMESTAMPTZ);
+                break;
+            case CHAR:
+            case NCHAR:
+            case VARCHAR:
+            case NVARCHAR:
+            case LONGVARCHAR:
+            case LONGNVARCHAR:
+                type.append(TYPE_VARCHAR);
+                if (f.precision() > 0) {
+                    // The maximum length n has no effect and is only provided for compatibility.
+                    type.append('(').append(f.precision()).append(')');
+                }
+                break;
+            case BINARY:
+            case BLOB:
+            case VARBINARY:
+                type.append(TYPE_BLOB);
+                break;
+            // case ARRAY:
+            // case OTHER:
+            // case NULL:
+            default:
+                log.warn("Not sure how to map JDBC type [%s], use VARCHAR instead", f.type());
+                type.append(TYPE_VARCHAR);
+                break;
+        }
+        if (!f.isNullable()) {
+            type.append(" NOT NULL");
+        }
+        return type.toString();
+    }
+
+    @Override
+    public String toRemoteTable(String url, Format format, Compression compress, Result<?> result) {
+        if (format == null || result == null) {
+            return ResultMapper.super.toRemoteTable(url, format, compress, result);
+        }
+
+        final String struct = toStructDefinition(result.fields().toArray(new Field[0]));
+        StringBuilder builder = new StringBuilder();
+        switch (format) {
+            case JSONL:
+            case NDJSON:
+                builder.append(FUNC_READ_JSON).append("('").append(url).append("',format='newline_delimited'");
+                break;
+            case TSV:
+                builder.append(FUNC_READ_CSV).append("('").append(url).append("',delim='\\t',header=true");
+                break;
+            case CSV:
+            default:
+                builder.append(FUNC_READ_CSV).append("('").append(url).append("',header=true");
+                break;
+        }
+
+        builder.append(",columns=").append(struct);
+        if (compress != null && compress != Compression.NONE) {
+            builder.append(",compression='").append(compress.encoding()).append('\'');
+        }
+        return builder.append(")").toString();
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/driver/ConnectionManager.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/ConnectionManager.java
@@ -25,6 +25,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -147,6 +148,7 @@ public final class ConnectionManager implements AutoCloseable {
     private final Connection conn;
     private final String bridgeUrl;
     private final Properties bridgeConfig;
+    private final String bridgeToken;
     private final String jdbcUrl;
     private final Properties props;
     private final Properties normalizedProps;
@@ -184,6 +186,10 @@ public final class ConnectionManager implements AutoCloseable {
         }
         this.bridgeUrl = bridge;
         this.bridgeConfig = new Properties();
+
+        String token = Option.SERVER_TOKEN.getJdbcxValue(originalProps).trim();
+        this.bridgeToken = Checker.isNullOrEmpty(token) ? token
+                : Base64.getEncoder().encodeToString(token.getBytes(Constants.DEFAULT_CHARSET));
 
         this.jdbcUrl = url;
         this.props = extensionProps;
@@ -341,6 +347,15 @@ public final class ConnectionManager implements AutoCloseable {
             }
         }
         return new Properties(bridgeConfig);
+    }
+
+    /**
+     * Gets base64 encoded token to access bridge server.
+     *
+     * @return non-null base64 encoded token
+     */
+    public String getBridgeToken() {
+        return bridgeToken;
     }
 
     public String getJdbcUrl() {

--- a/driver/src/main/java/io/github/jdbcx/driver/ConnectionMetaData.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/ConnectionMetaData.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.driver;
+
+import java.sql.DatabaseMetaData;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Constants;
+
+public final class ConnectionMetaData {
+    static String merge(String name, String version) {
+        if (version.isEmpty()) {
+            return name;
+        }
+        return new StringBuilder(name.length() + version.length() + 1).append(name).append('/').append(version)
+                .toString();
+    }
+
+    private final String packageName;
+    private final String productName;
+    private final String productVersion;
+    private final String driverName;
+    private final String driverVersion;
+    private final String userName;
+    private final String url;
+
+    ConnectionMetaData(String packageName) {
+        this.packageName = packageName;
+        this.productName = Constants.EMPTY_STRING;
+        this.productVersion = Constants.EMPTY_STRING;
+        this.driverName = Constants.EMPTY_STRING;
+        this.driverVersion = Constants.EMPTY_STRING;
+        this.userName = Constants.EMPTY_STRING;
+        this.url = Constants.EMPTY_STRING;
+    }
+
+    ConnectionMetaData(DatabaseMetaData metaData) {
+        this.packageName = metaData.getClass().getPackage().getName();
+
+        String value = null;
+        try {
+            value = metaData.getDatabaseProductName();
+        } catch (Exception e) {
+            // ignore
+        }
+        this.productName = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+
+        try {
+            value = new StringBuilder().append(metaData.getDatabaseMajorVersion()).append('.')
+                    .append(metaData.getDatabaseMinorVersion()).toString();
+        } catch (Exception e) {
+            try {
+                value = metaData.getDatabaseProductVersion();
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+        this.productVersion = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+
+        try {
+            value = metaData.getDriverName();
+        } catch (Exception e) {
+            // ignore
+        }
+        this.driverName = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+
+        try {
+            value = new StringBuilder().append(metaData.getDriverMajorVersion()).append('.')
+                    .append(metaData.getDriverMinorVersion()).toString();
+        } catch (Exception e) {
+            try {
+                value = metaData.getDriverVersion();
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+        this.driverVersion = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+
+        try {
+            value = metaData.getUserName();
+        } catch (Exception e) {
+            // ignore
+        }
+        this.userName = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+
+        try {
+            value = metaData.getURL();
+        } catch (Exception e) {
+            // ignore
+        }
+        this.url = Checker.isNullOrEmpty(value) ? Constants.EMPTY_STRING : value;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getProductVersion() {
+        return productVersion;
+    }
+
+    public String getProduct() {
+        return productName.isEmpty() ? packageName : merge(productName, productVersion);
+    }
+
+    public String getDriverName() {
+        return driverName;
+    }
+
+    public String getDriverVersion() {
+        return driverVersion;
+    }
+
+    public String getDriver() {
+        return driverName.isEmpty() ? packageName : merge(driverName, driverVersion);
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public boolean hasUserName() {
+        return !userName.isEmpty();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime + packageName.hashCode();
+        result = prime * result + productName.hashCode();
+        result = prime * result + productVersion.hashCode();
+        result = prime * result + driverName.hashCode();
+        result = prime * result + driverVersion.hashCode();
+        result = prime * result + userName.hashCode();
+        result = prime * result + url.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ConnectionMetaData other = (ConnectionMetaData) obj;
+        return packageName.equals(other.packageName) && productName.equals(other.productName)
+                && productVersion.equals(other.productVersion) && driverName.equals(other.driverName)
+                && driverVersion.equals(other.driverVersion) && userName.equals(other.userName)
+                && url.equals(other.url);
+    }
+}

--- a/driver/src/main/java/io/github/jdbcx/driver/DefaultDriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/DefaultDriverExtension.java
@@ -25,7 +25,7 @@ import io.github.jdbcx.executor.CommandLineExecutor;
 
 public final class DefaultDriverExtension implements DriverExtension {
     private static final List<Option> options = Collections.unmodifiableList(
-            Arrays.asList(Option.SERVER_URL, Option.CONFIG_PATH, Option.CUSTOM_CLASSPATH,
+            Arrays.asList(Option.SERVER_URL, Option.SERVER_TOKEN, Option.CONFIG_PATH, Option.CUSTOM_CLASSPATH,
                     CommandLineExecutor.OPTION_DOCKER_PATH, Option.PROXY, Option.TAG));
 
     private static final DriverExtension instance = new DefaultDriverExtension();

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
@@ -37,6 +37,7 @@ import io.github.jdbcx.Result;
 import io.github.jdbcx.Row;
 import io.github.jdbcx.Utils;
 import io.github.jdbcx.VariableTag;
+import io.github.jdbcx.executor.WebExecutor;
 import io.github.jdbcx.executor.jdbc.SqlExceptionUtils;
 import io.github.jdbcx.interpreter.WebInterpreter;
 
@@ -61,9 +62,17 @@ public final class QueryBuilder {
         for (int i = 0, len = blocks.length; i < len; i++) {
             ExecutableBlock block = this.blocks[i];
             if (block.useBridge()) {
+                ConnectionMetaData md = manager.getMetaData();
                 Properties props = manager.getBridgeConfig();
                 VariableTag tag = VariableTag.valueOf(Option.TAG.getValue(props));
                 WebInterpreter.OPTION_BASE_URL.setValue(props, manager.getBridgeUrl());
+                StringBuilder builder = new StringBuilder(WebExecutor.HEADER_USER_AGENT)
+                        .append('=').append(Utils.escape(md.getProduct(), ','));
+                if (md.hasUserName()) {
+                    builder.append(',').append(WebExecutor.HEADER_QUERY_USER).append('=')
+                            .append(Utils.escape(md.getUserName(), ','));
+                }
+                WebInterpreter.OPTION_REQUEST_HEADERS.setValue(props, builder.toString());
                 final String fullQuery;
                 if (block.hasOutput()) {
                     fullQuery = tag.function(block.getContent());

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
@@ -28,11 +28,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
+import io.github.jdbcx.Checker;
 import io.github.jdbcx.Constants;
 import io.github.jdbcx.DriverExtension;
 import io.github.jdbcx.JdbcActivityListener;
 import io.github.jdbcx.Option;
 import io.github.jdbcx.QueryContext;
+import io.github.jdbcx.QueryMode;
 import io.github.jdbcx.Result;
 import io.github.jdbcx.Row;
 import io.github.jdbcx.Utils;
@@ -66,14 +68,20 @@ public final class QueryBuilder {
                 Properties props = manager.getBridgeConfig();
                 VariableTag tag = VariableTag.valueOf(Option.TAG.getValue(props));
                 WebInterpreter.OPTION_BASE_URL.setValue(props, manager.getBridgeUrl());
-                StringBuilder builder = new StringBuilder(WebExecutor.HEADER_USER_AGENT)
-                        .append('=').append(Utils.escape(md.getProduct(), ','));
+                StringBuilder builder = new StringBuilder(WebExecutor.HEADER_USER_AGENT).append('=')
+                        .append(Utils.escape(md.getProduct(), ',')).append(',').append(WebExecutor.HEADER_QUERY_MODE)
+                        .append('=').append(QueryMode.ASYNC.code());
                 if (md.hasUserName()) {
                     builder.append(',').append(WebExecutor.HEADER_QUERY_USER).append('=')
                             .append(Utils.escape(md.getUserName(), ','));
                 }
                 WebInterpreter.OPTION_REQUEST_HEADERS.setValue(props, builder.toString());
+                final String token = manager.getBridgeToken();
+                if (!Checker.isNullOrEmpty(token) && Boolean.parseBoolean(Option.SERVER_AUTH.getValue(props))) {
+                    WebInterpreter.OPTION_AUTH_BEARER_TOKEN.setValue(props, token);
+                }
                 final String fullQuery;
+                // TODO escaping when server uses different variable tag
                 if (block.hasOutput()) {
                     fullQuery = tag.function(block.getContent());
                 } else {

--- a/driver/src/test/java/io/github/jdbcx/QueryModeTest.java
+++ b/driver/src/test/java/io/github/jdbcx/QueryModeTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jdbcx.server;
+package io.github.jdbcx;
 
 import java.util.Locale;
 
@@ -23,10 +23,12 @@ import org.testng.annotations.Test;
 public class QueryModeTest {
     @Test(groups = { "unit" })
     public void testConstructor() {
-        Assert.assertEquals(QueryMode.of(null), QueryMode.SUBMIT_QUERY);
-        Assert.assertEquals(QueryMode.of(""), QueryMode.SUBMIT_QUERY);
+        Assert.assertEquals(QueryMode.of(null), QueryMode.SUBMIT);
+        Assert.assertEquals(QueryMode.of(""), QueryMode.SUBMIT);
         for (QueryMode m : QueryMode.values()) {
             Assert.assertEquals(QueryMode.of(m.code()), m);
+            Assert.assertEquals(QueryMode.of(m.name()), m);
+            Assert.assertEquals(QueryMode.of(m.name().toLowerCase()), m);
             Assert.assertEquals(QueryMode.of(m.code().toLowerCase(Locale.ROOT)), m);
             Assert.assertEquals(QueryMode.of(m.code().toUpperCase(Locale.ROOT)), m);
         }

--- a/driver/src/test/java/io/github/jdbcx/ResultMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/ResultMapperTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.sql.JDBCType;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ResultMapperTest {
+    static final class TestMapper implements ResultMapper {
+        @Override
+        public String toColumnType(Field f) {
+            return f.type().name();
+        }
+    }
+
+    protected final ResultMapper mapper;
+
+    protected ResultMapperTest(ResultMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public ResultMapperTest() {
+        this(new TestMapper());
+    }
+
+    @Test(groups = { "unit" })
+    public void testQuoteIdentifier() {
+        Assert.assertEquals(mapper.quoteIdentifier(null), "\"null\"");
+        Assert.assertEquals(mapper.quoteIdentifier(""), "\"\"");
+        Assert.assertEquals(mapper.quoteIdentifier("123"), "\"123\"");
+        Assert.assertEquals(mapper.quoteIdentifier("1\"3"), "\"1\"\"3\"");
+        Assert.assertEquals(mapper.quoteIdentifier("1\\3"), "\"1\\3\"");
+        Assert.assertEquals(mapper.quoteIdentifier("1`3"), "\"1`3\"");
+    }
+
+    @Test(groups = { "unit" })
+    public void testToColumnType() {
+        for (JDBCType t : JDBCType.values()) {
+            Assert.assertEquals(mapper.toColumnType(Field.of("a\"b", t)), t.getName());
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testToColumnDefinition() {
+        Assert.assertEquals(mapper.toColumnDefinition(), "");
+        Assert.assertEquals(mapper.toColumnDefinition(Field.of("a\"b", JDBCType.BLOB)), "\"a\"\"b\" BLOB");
+        Assert.assertEquals(mapper.toColumnDefinition(Field.of("a", JDBCType.INTEGER), Field.of("b", JDBCType.VARCHAR)),
+                "\"a\" INTEGER,\"b\" VARCHAR");
+    }
+
+    @Test(groups = { "unit" })
+    public void testToRemoteTable() {
+        Assert.assertEquals(mapper.toRemoteTable(null, null, null, null), "'null'");
+        Assert.assertEquals(mapper.toRemoteTable("", null, null, null), "''");
+        Assert.assertEquals(mapper.toRemoteTable("http://localhost:8080/", null, null, null),
+                "'http://localhost:8080/'");
+    }
+}

--- a/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import java.sql.JDBCType;
+import java.util.Arrays;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.ResultMapperTest;
+
+public class ClickHouseMapperTest extends ResultMapperTest {
+    public ClickHouseMapperTest() {
+        super(new ClickHouseMapper());
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testQuoteIdentifier() {
+        Assert.assertEquals(mapper.quoteIdentifier(null), "`null`");
+        Assert.assertEquals(mapper.quoteIdentifier(""), "``");
+        Assert.assertEquals(mapper.quoteIdentifier("123"), "`123`");
+        Assert.assertEquals(mapper.quoteIdentifier("1`3"), "`1\\`3`");
+        Assert.assertEquals(mapper.quoteIdentifier("1\\3"), "`1\\\\3`");
+        Assert.assertEquals(mapper.quoteIdentifier("1\"3"), "`1\"3`");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnDefinition() {
+        Assert.assertEquals(mapper.toColumnDefinition(), "");
+        Assert.assertEquals(mapper.toColumnDefinition(Field.of("a`b", JDBCType.BLOB)), "`a\\`b` Nullable(String)");
+        Assert.assertEquals(
+                mapper.toColumnDefinition(Field.of("a", JDBCType.INTEGER, true, 24, 0, false),
+                        Field.of("b", JDBCType.CHAR, false, 3, 0, false)),
+                "`a` Nullable(UInt32),`b` FixedString(3)");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnType() {
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR, false)), "String");
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR)), "Nullable(String)");
+
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.TIMESTAMP, false, 0, 5, false)),
+                "DateTime64(5)");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToRemoteTable() {
+        Assert.assertEquals(mapper.toRemoteTable(null, null, null, null), "url('null',LineAsString)");
+        Assert.assertEquals(mapper.toRemoteTable("", null, null, null), "url('',LineAsString)");
+        Assert.assertEquals(mapper.toRemoteTable("", null, Compression.NONE, null), "url('',LineAsString)");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, null, null),
+                "url('',TSVWithNames,headers('accept'='text/tab-separated-values'))");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, Compression.NONE, null),
+                "url('',TSVWithNames,headers('accept'='text/tab-separated-values'))");
+
+        Result<?> result = Result.of(
+                Arrays.asList(Field.of("a`b", JDBCType.BIT), Field.of("c", JDBCType.DECIMAL, false, 18, 3, true)),
+                new Object[0]);
+        Assert.assertEquals(mapper.toRemoteTable("", null, null, result),
+                "url('',CSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)')");
+        Assert.assertEquals(mapper.toRemoteTable("", null, Compression.NONE, result),
+                "url('',CSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)')");
+
+        Assert.assertEquals(mapper.toRemoteTable("123", Format.CSV, Compression.NONE, result),
+                "url('123',CSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='text/csv'))");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, Compression.GZIP, result),
+                "url('',TSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='text/tab-separated-values','accept-encoding'='gzip'))");
+    }
+}

--- a/driver/src/test/java/io/github/jdbcx/dialect/DefaultMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/dialect/DefaultMapperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import java.sql.JDBCType;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Field;
+import io.github.jdbcx.ResultMapperTest;
+
+public class DefaultMapperTest extends ResultMapperTest {
+    public DefaultMapperTest() {
+        super(new DefaultMapper());
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnDefinition() {
+        Assert.assertEquals(mapper.toColumnDefinition(), "");
+        Assert.assertEquals(mapper.toColumnDefinition(Field.of("a\"b", JDBCType.BLOB)), "\"a\"\"b\" VARCHAR NULL");
+        Assert.assertEquals(
+                mapper.toColumnDefinition(Field.of("a", JDBCType.INTEGER, true, 24, 0, false),
+                        Field.of("b", JDBCType.CHAR, false, 3, 0, false)),
+                "\"a\" INTEGER NULL,\"b\" CHAR(3) NOT NULL");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnType() {
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR, false, 3, 0, false)), "CHAR(3) NOT NULL");
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR)), "VARCHAR NULL");
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.TIMESTAMP, false, 0, 5, false)),
+                "DATETIME NOT NULL");
+    }
+}

--- a/driver/src/test/java/io/github/jdbcx/dialect/DuckDBMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/dialect/DuckDBMapperTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.dialect;
+
+import java.sql.JDBCType;
+import java.util.Arrays;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.ResultMapperTest;
+
+public class DuckDBMapperTest extends ResultMapperTest {
+    public DuckDBMapperTest() {
+        super(new DuckDBMapper());
+    }
+
+    @Test(groups = { "unit" })
+    public void testToStructDefinition() {
+        Assert.assertEquals(((DuckDBMapper) mapper).toStructDefinition(), "{}");
+        Assert.assertEquals(((DuckDBMapper) mapper).toStructDefinition(Field.of("a\"b", JDBCType.BLOB)),
+                "{\"a\"\"b\":'BLOB'}");
+        Assert.assertEquals(
+                ((DuckDBMapper) mapper).toStructDefinition(Field.of("a", JDBCType.INTEGER, true, 24, 0, false),
+                        Field.of("b", JDBCType.CHAR, false, 3, 0, false)),
+                "{\"a\":'UINTEGER',\"b\":'VARCHAR(3) NOT NULL'}");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnDefinition() {
+        Assert.assertEquals(mapper.toColumnDefinition(), "");
+        Assert.assertEquals(mapper.toColumnDefinition(Field.of("a\"b", JDBCType.BLOB)), "\"a\"\"b\" BLOB");
+        Assert.assertEquals(
+                mapper.toColumnDefinition(Field.of("a", JDBCType.INTEGER, true, 24, 0, false),
+                        Field.of("b", JDBCType.CHAR, false, 3, 0, false)),
+                "\"a\" UINTEGER,\"b\" VARCHAR(3) NOT NULL");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToColumnType() {
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR, false, 3, 0, false)),
+                "VARCHAR(3) NOT NULL");
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.CHAR)), "VARCHAR");
+        Assert.assertEquals(mapper.toColumnType(Field.of("f", JDBCType.TIMESTAMP, false, 0, 5, false)),
+                "TIMESTAMP_MS NOT NULL");
+    }
+
+    @Test(groups = { "unit" })
+    @Override
+    public void testToRemoteTable() {
+        Assert.assertEquals(mapper.toRemoteTable(null, null, null, null), "'null'");
+        Assert.assertEquals(mapper.toRemoteTable("", null, null, null), "''");
+        Assert.assertEquals(mapper.toRemoteTable("", null, Compression.NONE, null), "''");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, null, null), "''");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, Compression.NONE, null), "''");
+
+        Result<?> result = Result.of(
+                Arrays.asList(Field.of("a\"b", JDBCType.BIT), Field.of("c", JDBCType.DECIMAL, false, 18, 3, true)),
+                new Object[0]);
+        Assert.assertEquals(mapper.toRemoteTable("", null, null, result), "''");
+        Assert.assertEquals(mapper.toRemoteTable("", null, Compression.NONE, result), "''");
+
+        Assert.assertEquals(mapper.toRemoteTable("123", Format.CSV, Compression.NONE, result),
+                "read_csv_auto('123',header=true,columns={\"a\"\"b\":'BOOLEAN',\"c\":'DECIMAL(18,3) NOT NULL'})");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, Compression.GZIP, result),
+                "read_csv_auto('',delim='\\t',header=true,columns={\"a\"\"b\":'BOOLEAN',\"c\":'DECIMAL(18,3) NOT NULL'},compression='gzip')");
+    }
+}

--- a/driver/src/test/java/io/github/jdbcx/driver/ConnectionManagerTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/ConnectionManagerTest.java
@@ -34,10 +34,10 @@ public class ConnectionManagerTest extends BaseIntegrationTest {
     public Object[][] getDatabaseProducts() {
         return new Object[][] {
                 // jdbcUrl, expected product name
-                { "jdbcx:", "JDBCX " },
-                { "jdbcx:sqlite::memory:", "SQLite " },
-                { "jdbcx:duckdb:", "DuckDB " },
-                { "jdbcx:ch://" + getClickHouseServer(), "ClickHouse " }
+                { "jdbcx:", "JDBCX/" },
+                { "jdbcx:sqlite::memory:", "SQLite/" },
+                { "jdbcx:duckdb:", "DuckDB/" },
+                { "jdbcx:ch://" + getClickHouseServer(), "ClickHouse/" }
         };
     }
 
@@ -75,7 +75,7 @@ public class ConnectionManagerTest extends BaseIntegrationTest {
             Assert.assertTrue(conn instanceof ManagedConnection, "Should return managed connection");
             ConnectionManager manager = ((ManagedConnection) conn).getManager();
             Assert.assertNotNull(manager, "Should have non-null connection manager");
-            Assert.assertTrue(ConnectionManager.getDatabaseProduct(conn).startsWith(productName),
+            Assert.assertTrue(manager.getMetaData().getProduct().startsWith(productName),
                     Utils.format("Product name should start with '%s'", productName));
         }
     }

--- a/driver/src/test/java/io/github/jdbcx/driver/ConnectionMetaDataTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/ConnectionMetaDataTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.driver;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConnectionMetaDataTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() throws SQLException {
+        ConnectionMetaData md = new ConnectionMetaData("1.2.3");
+        Assert.assertEquals(md.getPackageName(), "1.2.3");
+        Assert.assertEquals(md.getProduct(), "1.2.3");
+        Assert.assertEquals(md.getDriver(), "1.2.3");
+        Assert.assertEquals(md.getProductName(), "");
+        Assert.assertEquals(md.getProductVersion(), "");
+        Assert.assertEquals(md.getDriverName(), "");
+        Assert.assertEquals(md.getDriverVersion(), "");
+        Assert.assertEquals(md.getUserName(), "");
+        Assert.assertEquals(md.getUrl(), "");
+
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseMetaData d = conn.getMetaData();
+            md = new ConnectionMetaData(conn.getMetaData());
+            Assert.assertEquals(md.getPackageName(), conn.getClass().getPackage().getName());
+            Assert.assertEquals(md.getProduct(),
+                    d.getDatabaseProductName() + "/" + d.getDatabaseMajorVersion() + "." + d.getDatabaseMinorVersion());
+            Assert.assertEquals(md.getProductName(), d.getDatabaseProductName());
+            Assert.assertEquals(md.getProductVersion(),
+                    d.getDatabaseMajorVersion() + "." + d.getDatabaseMinorVersion());
+            Assert.assertEquals(md.getDriver(),
+                    d.getDriverName() + "/" + d.getDriverMajorVersion() + "." + d.getDriverMinorVersion());
+            Assert.assertEquals(md.getDriverName(), d.getDriverName());
+            Assert.assertEquals(md.getDriverVersion(), d.getDriverMajorVersion() + "." + d.getDriverMinorVersion());
+            Assert.assertEquals(md.getUserName(), "");
+            Assert.assertEquals(md.getUrl(), d.getURL());
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testEquals() throws SQLException {
+        Assert.assertEquals(new ConnectionMetaData("1" + "2"), new ConnectionMetaData("312".substring(1)));
+
+        try (Connection conn1 = DriverManager.getConnection("jdbc:sqlite::memory:");
+                Connection conn2 = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            Assert.assertEquals(new ConnectionMetaData(conn1.getMetaData()),
+                    new ConnectionMetaData(conn2.getMetaData()));
+        }
+    }
+}

--- a/server/src/main/java/io/github/jdbcx/server/QueryInfo.java
+++ b/server/src/main/java/io/github/jdbcx/server/QueryInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.server;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Constants;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Result;
+
+final class QueryInfo implements AutoCloseable, Serializable {
+    final String qid;
+    final String query;
+    final String txid;
+    final Format format;
+    final Compression compress;
+    final String token;
+    final String user;
+    final String client;
+
+    private transient AtomicReference<Result<?>> result;
+    private transient AtomicReference<AutoCloseable[]> resources;
+
+    QueryInfo(String qid, String query, String txid, Format format, Compression compress, String token, String user,
+            String client) {
+        if (Checker.isNullOrEmpty(qid)) {
+            this.qid = UUID.randomUUID().toString();
+        } else {
+            this.qid = qid;
+        }
+        this.query = Checker.isNullOrBlank(query) ? Constants.EMPTY_STRING : query;
+        this.txid = txid != null ? txid : Constants.EMPTY_STRING;
+        this.format = format != null ? format : Format.TSV;
+        this.compress = compress != null ? compress : Compression.NONE;
+        this.token = token != null ? token : Constants.EMPTY_STRING;
+        this.user = user != null ? user : Constants.EMPTY_STRING;
+        this.client = client != null ? client : Constants.EMPTY_STRING;
+
+        this.result = new AtomicReference<>();
+        this.resources = new AtomicReference<>();
+    }
+
+    Result<?> getResult() { // NOSONAR
+        return this.result.get();
+    }
+
+    AutoCloseable[] getResources() {
+        AutoCloseable[] arr = this.resources.get();
+        final int len;
+        if (arr == null || (len = arr.length) == 0) {
+            return arr;
+        }
+
+        AutoCloseable[] res = new AutoCloseable[len];
+        for (int i = 0; i < len; i++) {
+            res[i] = arr[i]; // NOSONAR
+        }
+        return res;
+    }
+
+    @SuppressWarnings("resource")
+    QueryInfo setResult(Result<?> result) {
+        if (result == null) {
+            throw new IllegalArgumentException("Non-null result is required");
+        } else if (!this.result.compareAndSet(null, result)) {
+            throw new IllegalStateException("Cannot replace non-null result: " + this.result.get());
+        }
+        return this;
+    }
+
+    QueryInfo setResources(AutoCloseable... resources) {
+        final int len;
+        if (resources == null || (len = resources.length) == 0) {
+            throw new IllegalArgumentException("At least one AutoCloseable resource is required");
+        } else {
+            List<AutoCloseable> list = new ArrayList<>(len);
+            for (int i = 0; i < len; i++) {
+                AutoCloseable r = resources[i];
+                if (r != null) {
+                    list.add(r);
+                }
+            }
+            if (list.isEmpty()) {
+                throw new IllegalArgumentException("At least one non-null AutoCloseable is required");
+            } else if (!this.resources.compareAndSet(null, list.toArray(new AutoCloseable[0]))) {
+                throw new IllegalStateException("Cannot replace non-null resources: " + this.resources.get());
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public void close() {
+        final Result<?> r = this.result.getAndUpdate(v -> null);
+        if (r != null) {
+            try {
+                r.close();
+            } catch (Throwable t) { // NOSONAR
+                // ignore
+            }
+        }
+
+        final AutoCloseable[] res = this.resources.getAndUpdate(v -> null);
+        if (res != null) {
+            for (int i = 0, len = res.length; i < len; i++) {
+                try {
+                    res[i].close();
+                } catch (Throwable t) { // NOSONAR
+                    // ignore
+                }
+            }
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hash = prime + qid.hashCode();
+        hash = prime * hash + query.hashCode();
+        hash = prime * hash + txid.hashCode();
+        hash = prime * hash + format.hashCode();
+        hash = prime * hash + compress.hashCode();
+        hash = prime * hash + token.hashCode();
+        hash = prime * hash + user.hashCode();
+        hash = prime * hash + client.hashCode();
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        QueryInfo other = (QueryInfo) obj;
+        return qid.equals(other.qid) && query.equals(other.query) && txid.equals(other.txid) && format == other.format
+                && compress == other.compress && token.equals(other.token) && user.equals(other.user)
+                && client.equals(other.client);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(hashCode()).append("[id=").append(qid)
+                .append(", tx=").append(txid).append(", fmt=").append(format).append(", comp=").append(compress)
+                .append(", user=").append(user).append(", client=").append(client).append("]:\n").append(query)
+                .toString();
+    }
+}

--- a/server/src/main/java/io/github/jdbcx/server/QueryMode.java
+++ b/server/src/main/java/io/github/jdbcx/server/QueryMode.java
@@ -16,7 +16,11 @@
 package io.github.jdbcx.server;
 
 public enum QueryMode {
-    SUBMIT_QUERY("s"), SUBMIT_REDIRECT("r"), DIRECT_QUERY("d"), MUTATION("m");
+    SUBMIT_QUERY("s"), // submit query without execution
+    SUBMIT_REDIRECT("r"), // submit query and redirect
+    ASYNC_QUERY("a"),
+    DIRECT_QUERY("d"), // execute query
+    MUTATION("m"); // mutation
 
     private String code;
 
@@ -34,6 +38,10 @@ public enum QueryMode {
             mode = SUBMIT_QUERY;
         } else if (str.length() == 1) {
             switch (str.charAt(0)) {
+                case 'a':
+                case 'A':
+                    mode = ASYNC_QUERY;
+                    break;
                 case 's':
                 case 'S':
                     mode = SUBMIT_QUERY;

--- a/server/src/main/java/io/github/jdbcx/server/Request.java
+++ b/server/src/main/java/io/github/jdbcx/server/Request.java
@@ -23,6 +23,7 @@ import io.github.jdbcx.Checker;
 import io.github.jdbcx.Compression;
 import io.github.jdbcx.Constants;
 import io.github.jdbcx.Format;
+import io.github.jdbcx.JdbcDialect;
 
 public class Request implements Serializable {
     protected final QueryMode mode;
@@ -34,10 +35,12 @@ public class Request implements Serializable {
     protected final Format format;
     protected final Compression compress;
 
+    protected final transient JdbcDialect dialect;
+
     protected final transient Object userObject;
 
     protected Request(String method, QueryMode mode, String qid, String query, String txid, Format format,
-            Compression compress, Object userObject) {
+            Compression compress, JdbcDialect dialect, Object userObject) {
         this.method = method != null ? method : Constants.EMPTY_STRING;
         this.mode = mode != null ? mode : QueryMode.SUBMIT_QUERY;
         if (Checker.isNullOrEmpty(qid)) {
@@ -51,6 +54,8 @@ public class Request implements Serializable {
         this.txid = txid != null ? txid : Constants.EMPTY_STRING;
         this.format = format != null ? format : Format.TSV;
         this.compress = compress != null ? compress : Compression.NONE;
+
+        this.dialect = dialect;
         this.userObject = userObject;
     }
 
@@ -96,6 +101,10 @@ public class Request implements Serializable {
 
     public Compression getCompression() {
         return compress;
+    }
+
+    public JdbcDialect getDialect() {
+        return dialect;
     }
 
     public <T> T getUserObject(Class<T> clazz) {

--- a/server/src/main/java/io/github/jdbcx/server/ServerAcl.java
+++ b/server/src/main/java/io/github/jdbcx/server/ServerAcl.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.server;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Utils;
+
+// client1.token=123
+// client1.allowedHosts=a,b,c
+// client1.allowedIPs=192.168.0.0/16
+final class ServerAcl {
+    static class IPRange {
+        final InetAddress start;
+        final InetAddress end;
+
+        IPRange(InetAddress start, InetAddress end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = prime + start.hashCode();
+            result = prime * result + end.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            IPRange other = (IPRange) obj;
+            return start.equals(other.start) && end.equals(other.end);
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder(IPRange.class.getSimpleName()).append('@').append(hashCode()).append('[')
+                    .append(start).append(',').append(end).append(']').toString();
+        }
+    }
+
+    static InetAddress getEndAddress(InetAddress start, int prefixLength) throws UnknownHostException {
+        final byte[] startBytes = Checker.nonNull(start, InetAddress.class).getAddress();
+        final int len = startBytes.length;
+        if (prefixLength < 0 || prefixLength > len * 8) {
+            throw new IllegalArgumentException(
+                    Utils.format("Invalid prefix length %d, expected range is [0, %d]", prefixLength, len * 8));
+        }
+        final byte[] endBytes = new byte[len];
+        System.arraycopy(startBytes, 0, endBytes, 0, len);
+
+        for (int i = len - 1; prefixLength < 8 * (i + 1); i--) {
+            endBytes[i] = (byte) (endBytes[i] | (1 << (8 * (i + 1) - prefixLength)) - 1);
+        }
+        return InetAddress.getByAddress(endBytes);
+    }
+
+    static boolean isInRange(InetAddress start, InetAddress end, InetAddress ip) {
+        byte[] startBytes = start.getAddress();
+        byte[] endBytes = end.getAddress();
+        byte[] ipBytes = ip.getAddress();
+        if (ipBytes.length != startBytes.length) {
+            return false;
+        }
+
+        // Check if ipBytes is between startBytes and endBytes
+        for (int i = 0, len = ipBytes.length; i < len; i++) {
+            if ((ipBytes[i] & 0xFF) < (startBytes[i] & 0xFF) || (ipBytes[i] & 0xFF) > (endBytes[i] & 0xFF)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    final String token;
+    final boolean allowAll;
+    final Set<String> allowedHosts;
+    final Set<String> allowedIPs;
+    final List<IPRange> ipRanges;
+
+    ServerAcl(String token, String allowedHosts, String allowedIPs) {
+        this.token = Checker.nonEmpty(token, "Token").trim();
+
+        if (Checker.isNullOrEmpty(allowedHosts)) {
+            this.allowedHosts = Collections.emptySet();
+        } else {
+            Set<String> set = new HashSet<>();
+            for (String host : Utils.split(allowedHosts, ',')) {
+                set.add(host.trim().toLowerCase(Locale.ROOT));
+            }
+            this.allowedHosts = Collections.unmodifiableSet(set);
+        }
+
+        if (Checker.isNullOrEmpty(allowedIPs)) {
+            this.allowedIPs = Collections.emptySet();
+            this.ipRanges = Collections.emptyList();
+        } else {
+            Set<String> set = new HashSet<>();
+            List<IPRange> list = new ArrayList<>();
+            for (String ip : Utils.split(allowedIPs, ',')) {
+                if (ip.indexOf('/') == -1) {
+                    set.add(ip.trim());
+                    continue;
+                }
+                List<String> parts = Utils.split(ip, '/');
+                if (parts.size() == 2) {
+                    try {
+                        InetAddress start = InetAddress.getByName(parts.get(0).trim());
+                        InetAddress end = getEndAddress(start, Integer.parseInt(parts.get(1).trim()));
+                        list.add(new IPRange(start, end));
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException(
+                                Utils.format("Failed to parse IP range [%s] due to: %s", ip, e.getMessage()));
+                    }
+                } else {
+                    throw new IllegalArgumentException(
+                            Utils.format("Invalid IP range [%s]", ip));
+                }
+            }
+            this.allowedIPs = Collections.unmodifiableSet(set);
+            this.ipRanges = Collections.unmodifiableList(list);
+        }
+        this.allowAll = this.allowedHosts.isEmpty() && this.allowedIPs.isEmpty() && this.ipRanges.isEmpty();
+    }
+
+    public boolean isValid(InetAddress address) {
+        if (allowAll) {
+            return true;
+        } else if (address == null) {
+            return false;
+        }
+        return isValidIP(address.getHostAddress()) || (!allowedHosts.isEmpty() && isValidHost(address.getHostName()));
+    }
+
+    public boolean isValidHost(String host) {
+        boolean isValid = true;
+        if (allowAll) {
+            return isValid;
+        } else if (Checker.isNullOrEmpty(host)) {
+            return false;
+        }
+        return allowedHosts.isEmpty() || allowedHosts.contains(host.toLowerCase(Locale.ROOT));
+    }
+
+    public boolean isValidIP(String ip) {
+        if (allowAll) {
+            return true;
+        } else if (Checker.isNullOrEmpty(ip)) {
+            return false;
+        }
+
+        if (!allowedIPs.isEmpty() && allowedIPs.contains(ip)) {
+            return true;
+        }
+
+        boolean isValid = true;
+        if (!ipRanges.isEmpty()) {
+            isValid = false;
+            InetAddress address = null;
+            try {
+                address = InetAddress.getByName(ip);
+            } catch (Exception e) {
+                return false;
+            }
+            for (IPRange range : ipRanges) {
+                if (isInRange(range.start, range.end, address)) {
+                    isValid = true;
+                    break;
+                }
+            }
+        }
+        return isValid;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime + token.hashCode();
+        result = prime * result + (allowAll ? 1231 : 1237);
+        result = prime * result + allowedHosts.hashCode();
+        result = prime * result + allowedIPs.hashCode();
+        result = prime * result + ipRanges.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ServerAcl other = (ServerAcl) obj;
+        return token.equals(other.token) && allowAll == other.allowAll && allowedHosts.equals(other.allowedHosts)
+                && allowedIPs.equals(other.allowedIPs) && ipRanges.equals(other.ipRanges);
+    }
+
+}

--- a/server/src/main/java/io/github/jdbcx/server/impl/JdkHttpServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/impl/JdkHttpServer.java
@@ -36,6 +36,7 @@ import io.github.jdbcx.Checker;
 import io.github.jdbcx.Compression;
 import io.github.jdbcx.Constants;
 import io.github.jdbcx.Format;
+import io.github.jdbcx.JdbcDialect;
 import io.github.jdbcx.Logger;
 import io.github.jdbcx.LoggerFactory;
 import io.github.jdbcx.Utils;
@@ -69,12 +70,12 @@ public final class JdkHttpServer extends BridgeServer implements HttpHandler {
 
     @Override
     protected Request create(String method, QueryMode mode, String qid, String query, String txid, Format format,
-            Compression compress, Object userObject) throws IOException {
+            Compression compress, JdbcDialect dialect, Object userObject) throws IOException {
         if (mode != QueryMode.MUTATION && Checker.isNullOrBlank(query)) {
             HttpExchange exchange = (HttpExchange) userObject;
             query = Stream.readAllAsString(exchange.getRequestBody());
         }
-        return super.create(method, mode, qid, query, txid, format, compress, userObject);
+        return super.create(method, mode, qid, query, txid, format, compress, dialect, userObject);
     }
 
     @Override

--- a/server/src/test/java/io/github/jdbcx/server/QueryInfoTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/QueryInfoTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.server;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.Result;
+
+public class QueryInfoTest {
+    static class TestResource implements AutoCloseable {
+        final AtomicBoolean closed = new AtomicBoolean(false);
+
+        @Override
+        public void close() {
+            closed.compareAndSet(false, true);
+        }
+    }
+
+    static class TroublesomeResource implements AutoCloseable {
+        @Override
+        public void close() {
+            throw new IllegalAccessError();
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        try (QueryInfo info = new QueryInfo(null, null, null, null, null, null, null, null)) {
+            Assert.assertTrue(info.qid.length() > 0);
+            Assert.assertEquals(info.query, "");
+            Assert.assertEquals(info.txid, "");
+            Assert.assertEquals(info.format, Format.TSV);
+            Assert.assertEquals(info.compress, Compression.NONE);
+            Assert.assertEquals(info.token, "");
+            Assert.assertEquals(info.user, "");
+            Assert.assertEquals(info.client, "");
+            Assert.assertNull(info.getResult());
+            Assert.assertNull(info.getResources());
+
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResult(null));
+            Assert.assertNull(info.getResult());
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources((AutoCloseable[]) null));
+            Assert.assertNull(info.getResources());
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources());
+            Assert.assertNull(info.getResources());
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources((AutoCloseable) null));
+            Assert.assertNull(info.getResources());
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources(null, null));
+            Assert.assertNull(info.getResources());
+        }
+
+        final String id1 = UUID.randomUUID().toString();
+        final String id2 = UUID.randomUUID().toString();
+        try (QueryInfo info = new QueryInfo(id1, "select 5", id2, Format.AVROB, Compression.SNAPPY, "233", "zhicwu",
+                "JDBCX/1.0")) {
+            Assert.assertEquals(info.qid, id1);
+            Assert.assertEquals(info.query, "select 5");
+            Assert.assertEquals(info.txid, id2);
+            Assert.assertEquals(info.format, Format.AVROB);
+            Assert.assertEquals(info.compress, Compression.SNAPPY);
+            Assert.assertEquals(info.token, "233");
+            Assert.assertEquals(info.user, "zhicwu");
+            Assert.assertEquals(info.client, "JDBCX/1.0");
+            Assert.assertNull(info.getResult());
+            Assert.assertNull(info.getResources());
+
+            info.setResult(Result.of("123"));
+            Assert.assertNotNull(info.getResult());
+            Assert.assertEquals(info.getResult().get(), "123");
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResult(null));
+            Assert.assertThrows(IllegalStateException.class, () -> info.setResult(Result.of("321")));
+            Assert.assertNotNull(info.getResult());
+            Assert.assertEquals(info.getResult().get(), "123");
+
+            AutoCloseable res1 = new TestResource();
+            AutoCloseable res2 = new TroublesomeResource();
+            AutoCloseable res3 = new TestResource();
+            info.setResources(null, res1, null, null, res2, null, null, null, res3, null);
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources((AutoCloseable[]) null));
+            Assert.assertThrows(IllegalArgumentException.class, () -> info.setResources());
+            Assert.assertThrows(IllegalStateException.class, () -> info.setResources(res1));
+            Assert.assertEquals(info.getResources(), new AutoCloseable[] { res1, res2, res3 });
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testClose() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("select 1")) {
+            Result<?> res = Result.of(rs);
+            QueryInfo info = new QueryInfo(null, null, null, null, null, null, null, null);
+            info.setResult(res);
+            Assert.assertFalse(rs.isClosed());
+            Assert.assertFalse(stmt.isClosed());
+            Assert.assertFalse(conn.isClosed());
+
+            info.close();
+            Assert.assertTrue(rs.isClosed());
+            Assert.assertFalse(stmt.isClosed());
+            Assert.assertFalse(conn.isClosed());
+
+            info.setResources(rs, stmt, conn);
+            info.close();
+            Assert.assertTrue(rs.isClosed());
+            Assert.assertTrue(stmt.isClosed());
+            Assert.assertTrue(conn.isClosed());
+        }
+    }
+}

--- a/server/src/test/java/io/github/jdbcx/server/RequestTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/RequestTest.java
@@ -20,26 +20,27 @@ import org.testng.annotations.Test;
 
 import io.github.jdbcx.Compression;
 import io.github.jdbcx.Format;
+import io.github.jdbcx.QueryMode;
 
 public class RequestTest {
     @Test(groups = { "unit" })
     public void testConstructor() {
-        Request request = new Request(null, null, null, null, null, null, null, null, null);
+        Request request = new Request(null, null, null, null, null, null, null, null, null, null, null, null);
         Assert.assertFalse(request.hasQueryId());
         Assert.assertFalse(request.isMutation());
         Assert.assertFalse(request.isTransactional());
         Assert.assertEquals(request.getMethod(), "");
-        Assert.assertEquals(request.getQueryMode(), QueryMode.SUBMIT_QUERY);
+        Assert.assertEquals(request.getQueryMode(), QueryMode.SUBMIT);
         Assert.assertEquals(request.getQuery(), "");
         Assert.assertEquals(request.getCompression(), Compression.NONE);
         Assert.assertEquals(request.getFormat(), Format.TSV);
         String qid = request.getQueryId();
         Assert.assertTrue(qid.length() > 0);
         Assert.assertEquals(request.getQueryId(), qid);
-        Assert.assertNull(request.getUserObject(Object.class));
+        Assert.assertNull(request.getImplementation(Object.class));
 
         request = new Request("HEAD", QueryMode.MUTATION, "123", "321", "tx1", Format.AVROB, Compression.SNAPPY, null,
-                request);
+                null, null, null, request);
         Assert.assertTrue(request.hasQueryId());
         Assert.assertTrue(request.isMutation());
         Assert.assertTrue(request.isTransactional());
@@ -49,21 +50,25 @@ public class RequestTest {
         Assert.assertEquals(request.getQueryId(), "123");
         Assert.assertEquals(request.getCompression(), Compression.SNAPPY);
         Assert.assertEquals(request.getFormat(), Format.AVROB);
-        Assert.assertNotNull(request.getUserObject(Request.class));
+        Assert.assertNotNull(request.getImplementation(Request.class));
     }
 
     @Test(groups = { "unit" })
     public void testToUrl() {
-        Request request = new Request(null, null, null, null, null, null, null, null, null);
-        Assert.assertEquals(request.toUrl(), request.getQueryId() + request.getFormat().fileExtension());
+        final String baseUrl = "http://localhost:1234/";
+        Request request = new Request(null, null, null, null, null, null, null, null, null, null, null, null);
+        Assert.assertEquals(request.toUrl(baseUrl),
+                baseUrl + request.getQueryId() + request.getFormat().fileExtension());
         Assert.assertEquals(request.toUrl(""), request.getQueryId() + request.getFormat().fileExtension());
         Assert.assertEquals(request.toUrl("/"), "/" + request.getQueryId() + request.getFormat().fileExtension());
-        request = new Request(null, QueryMode.DIRECT_QUERY, null, null, null, Format.BSON, Compression.LZ4, null, null);
-        Assert.assertEquals(request.toUrl(),
-                request.getQueryId() + request.getFormat().fileExtension() + request.getCompression().fileExtension());
-        request = new Request("POST", QueryMode.MUTATION, "123", "321", "567", Format.BSON, Compression.LZ4, null,
-                null);
-        Assert.assertEquals(request.toUrl(), "123.bson.lz4");
+        request = new Request(null, QueryMode.DIRECT, null, null, null, Format.BSON, Compression.LZ4, null, null,
+                null, null, null);
+        Assert.assertEquals(request.toUrl(baseUrl),
+                baseUrl + request.getQueryId() + request.getFormat().fileExtension()
+                        + request.getCompression().fileExtension());
+        request = new Request("POST", QueryMode.MUTATION, "123", "321", "567", Format.BSON, Compression.LZ4, null, null,
+                null, null, null);
+        Assert.assertEquals(request.toUrl(baseUrl), baseUrl + "123.bson.lz4");
         Assert.assertEquals(request.toUrl("http://localhost/"), "http://localhost/123.bson.lz4");
     }
 }

--- a/server/src/test/java/io/github/jdbcx/server/RequestTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/RequestTest.java
@@ -24,7 +24,7 @@ import io.github.jdbcx.Format;
 public class RequestTest {
     @Test(groups = { "unit" })
     public void testConstructor() {
-        Request request = new Request(null, null, null, null, null, null, null, null);
+        Request request = new Request(null, null, null, null, null, null, null, null, null);
         Assert.assertFalse(request.hasQueryId());
         Assert.assertFalse(request.isMutation());
         Assert.assertFalse(request.isTransactional());
@@ -38,7 +38,7 @@ public class RequestTest {
         Assert.assertEquals(request.getQueryId(), qid);
         Assert.assertNull(request.getUserObject(Object.class));
 
-        request = new Request("HEAD", QueryMode.MUTATION, "123", "321", "tx1", Format.AVROB, Compression.SNAPPY,
+        request = new Request("HEAD", QueryMode.MUTATION, "123", "321", "tx1", Format.AVROB, Compression.SNAPPY, null,
                 request);
         Assert.assertTrue(request.hasQueryId());
         Assert.assertTrue(request.isMutation());
@@ -54,14 +54,15 @@ public class RequestTest {
 
     @Test(groups = { "unit" })
     public void testToUrl() {
-        Request request = new Request(null, null, null, null, null, null, null, null);
+        Request request = new Request(null, null, null, null, null, null, null, null, null);
         Assert.assertEquals(request.toUrl(), request.getQueryId() + request.getFormat().fileExtension());
         Assert.assertEquals(request.toUrl(""), request.getQueryId() + request.getFormat().fileExtension());
         Assert.assertEquals(request.toUrl("/"), "/" + request.getQueryId() + request.getFormat().fileExtension());
-        request = new Request(null, QueryMode.DIRECT_QUERY, null, null, null, Format.BSON, Compression.LZ4, null);
+        request = new Request(null, QueryMode.DIRECT_QUERY, null, null, null, Format.BSON, Compression.LZ4, null, null);
         Assert.assertEquals(request.toUrl(),
                 request.getQueryId() + request.getFormat().fileExtension() + request.getCompression().fileExtension());
-        request = new Request("POST", QueryMode.MUTATION, "123", "321", "567", Format.BSON, Compression.LZ4, null);
+        request = new Request("POST", QueryMode.MUTATION, "123", "321", "567", Format.BSON, Compression.LZ4, null,
+                null);
         Assert.assertEquals(request.toUrl(), "123.bson.lz4");
         Assert.assertEquals(request.toUrl("http://localhost/"), "http://localhost/123.bson.lz4");
     }

--- a/server/src/test/java/io/github/jdbcx/server/ServerAclTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/ServerAclTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.server;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ServerAclTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() throws UnknownHostException {
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ServerAcl(null, null, null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ServerAcl("", null, null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ServerAcl("token", null, "192.168.1.1/3a"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ServerAcl("token", null, "192.168.1.1/1/2"));
+
+        ServerAcl acl = new ServerAcl("123", null, null);
+        Assert.assertTrue(acl.allowAll);
+        Assert.assertEquals(acl.allowedHosts, Collections.emptyList());
+        Assert.assertEquals(acl.allowedIPs, Collections.emptyList());
+        Assert.assertEquals(acl.ipRanges, Collections.emptyList());
+        Assert.assertTrue(acl.isValidHost("unknown.host"));
+        Assert.assertTrue(acl.isValidIP("192.168.5.6"));
+
+        acl = new ServerAcl("123", " host.1 , host.2 ", "");
+        Assert.assertFalse(acl.allowAll);
+        Assert.assertEquals(acl.allowedHosts, Arrays.asList("host.1", "host.2"));
+        Assert.assertEquals(acl.allowedIPs, Collections.emptyList());
+        Assert.assertEquals(acl.ipRanges, Collections.emptyList());
+        Assert.assertFalse(acl.isValidHost("unknown.host"));
+        Assert.assertTrue(acl.isValidHost("host.1"));
+        Assert.assertTrue(acl.isValidHost("host.2"));
+        Assert.assertTrue(acl.isValidIP("192.168.5.6"));
+
+        acl = new ServerAcl("123", "", " 192.168.3.1 , 192.168.1.2 / 24 ");
+        Assert.assertFalse(acl.allowAll);
+        Assert.assertEquals(acl.allowedHosts, Collections.emptyList());
+        Assert.assertEquals(acl.allowedIPs, Arrays.asList("192.168.3.1"));
+        Assert.assertEquals(acl.ipRanges, Collections.singletonList(
+                new ServerAcl.IPRange(InetAddress.getByName("192.168.1.2"), InetAddress.getByName("192.168.1.255"))));
+        Assert.assertTrue(acl.isValidHost("unknown.host"));
+        Assert.assertTrue(acl.isValidIP("192.168.3.1"));
+        Assert.assertFalse(acl.isValidIP("192.168.1.1"));
+        Assert.assertTrue(acl.isValidIP("192.168.1.5"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetEndAddress() throws UnknownHostException {
+        Assert.assertThrows(IllegalArgumentException.class, () -> ServerAcl.getEndAddress(null, 1));
+
+        final InetAddress ipv4 = InetAddress.getByName("192.168.1.3");
+        final InetAddress ipv6 = InetAddress.getByName("::1234:56a8:103");
+        Assert.assertThrows(IllegalArgumentException.class, () -> ServerAcl.getEndAddress(ipv4, -1));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ServerAcl.getEndAddress(ipv4, 33));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ServerAcl.getEndAddress(ipv6, -1));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ServerAcl.getEndAddress(ipv6, 129));
+
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv4, 0), InetAddress.getByName("255.255.255.3"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv4, 1), InetAddress.getByName("255.255.255.255"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv4, 2), InetAddress.getByName("255.255.255.255"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv4, 8), InetAddress.getByName("192.255.255.255"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv4, 24), InetAddress.getByName("192.168.1.255"));
+
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 0),
+                InetAddress.getByName("ffff:ff00:ffff:ff00:ffff:ff34:ffff:ff03"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 1),
+                InetAddress.getByName("7fff:ffff:7fff:ffff:7fff:ffff:7fff:ffff"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 2),
+                InetAddress.getByName("3fff:ffff:3fff:ffff:3fff:ffff:7fff:ffff"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 8),
+                InetAddress.getByName("ff:ffff:ff:ffff:ff:ffff:56ff:ffff"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 24),
+                InetAddress.getByName("0:ff:ffff:ff:ffff:12ff:ffff:1ff"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 33),
+                InetAddress.getByName("0:0:7fff:ffff:7fff:ffff:7fff:ffff"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 64),
+                InetAddress.getByName("0:0:0:0:ffff:ff34:ffff:ff03"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 96),
+                InetAddress.getByName("0:0:0:0:0:1234:ffff:ff03"));
+        Assert.assertEquals(ServerAcl.getEndAddress(ipv6, 128),
+                InetAddress.getByName("0:0:0:0:0:1234:56a8:103"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testIsInRange() throws UnknownHostException {
+        Assert.assertTrue(
+                ServerAcl.isInRange(InetAddress.getByName("192.168.3.1"), InetAddress.getByName("192.168.3.2"),
+                        InetAddress.getByName("192.168.3.1")));
+        ServerAcl.isInRange(InetAddress.getByName("192.168.3.1"), InetAddress.getByName("192.168.3.2"),
+                InetAddress.getByName("::ffff:c0a8:302"));
+        Assert.assertFalse(
+                ServerAcl.isInRange(InetAddress.getByName("192.168.3.1"), InetAddress.getByName("192.168.3.2"),
+                        InetAddress.getByName("192.168.3.5")));
+        Assert.assertFalse(
+                ServerAcl.isInRange(InetAddress.getByName("192.168.3.1"), InetAddress.getByName("192.168.3.2"),
+                        InetAddress.getByName("::1234:56a8:103")));
+
+        Assert.assertTrue(
+                ServerAcl.isInRange(InetAddress.getByName("::1234:56a8:101"), InetAddress.getByName("::1234:56a8:103"),
+                        InetAddress.getByName("::1234:56a8:101")));
+    }
+}

--- a/server/src/test/java/io/github/jdbcx/server/impl/JdkHttpServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/impl/JdkHttpServerTest.java
@@ -15,19 +15,12 @@
  */
 package io.github.jdbcx.server.impl;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.Properties;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import io.github.jdbcx.Option;
-import io.github.jdbcx.Utils;
-import io.github.jdbcx.WrappedDriver;
 import io.github.jdbcx.server.BaseBridgeServerTest;
 
 public class JdkHttpServerTest extends BaseBridgeServerTest {
@@ -52,49 +45,6 @@ public class JdkHttpServerTest extends BaseBridgeServerTest {
 
     // @Test(groups = { "integration" })
     // public void testAny() throws Exception {
-    //     super.testWriteConfig();
+    //     super.testDefaultBridge();
     // }
-
-    @Test(groups = { "integration" })
-    public void testConnect() throws Exception {
-        Properties props = new Properties();
-        WrappedDriver d = new WrappedDriver();
-
-        try (Connection conn = d.connect("jdbc:ch://" + getClickHouseServer(), props);
-                Statement stmt = conn.createStatement();) {
-            try (ResultSet rs = stmt
-                    .executeQuery("select * from url('" + getServerUrl() + "?q=select%201','LineAsString')")) {
-                Assert.assertEquals(rs.getMetaData().getColumnCount(), 1);
-                Assert.assertTrue(rs.next());
-                Assert.assertTrue(rs.getString(1).length() > 0);
-                Assert.assertFalse(rs.next());
-            }
-
-            try (ResultSet rs = stmt
-                    .executeQuery(
-                            "select * from url('" + getServerUrl() + "?m=d&q=select+1+as+r','CSVWithNames')")) {
-                Assert.assertEquals(rs.getMetaData().getColumnCount(), 1);
-                Assert.assertEquals(rs.getMetaData().getColumnName(1), "r");
-                Assert.assertTrue(rs.next());
-                Assert.assertEquals(rs.getString(1), "1");
-                Assert.assertFalse(rs.next());
-            }
-
-            int count = 70000;
-            String query = "select *, b::string as c from (select generate_series a, a*random() b from generate_series("
-                    + count + ",1,-1))";
-            try (ResultSet rs = stmt.executeQuery(
-                    "select * from url('" + getServerUrl() + "?m=d&q=" + Utils.encode(query) + "','CSVWithNames')")) {
-                Assert.assertEquals(rs.getMetaData().getColumnCount(), 3);
-                Assert.assertEquals(rs.getMetaData().getColumnName(1), "a");
-                Assert.assertEquals(rs.getMetaData().getColumnName(2), "b");
-                Assert.assertEquals(rs.getMetaData().getColumnName(3), "c");
-                while (rs.next()) {
-                    Assert.assertEquals(rs.getInt(1), count--);
-                    Assert.assertEquals(rs.getString(2), rs.getString(3));
-                }
-                Assert.assertEquals(count, 0);
-            }
-        }
-    }
 }


### PR DESCRIPTION
* pass context(database product and current user) from driver to bridge server
* add `ResultMapper` to optimize bridged query
  ```sql
  -- before(ClickHouse -> Bridge Server -> DuckDB)
  select *
  from url('{{ bridge.db:
    select generate_series a, generate_series * random() b from generate_series(1,1000000)
  }}', CSVWithNames)

  -- after(generate a more complete expression using dialect and mapper)
  -- below query is same as: select * from url('<url>', <format>, '<columns>', headers(<headers>))
  select *
  from {{ bridge.db:
    select generate_series a, generate_series * random() b from generate_series(1,1000000)
  }}
  ```
* add ASYNC query mode for type inferring
* add `jdbcx.server.auth` and `jdbcx.server.token` to secure bridge server 
* result mappers for DuckDB and ClickHouse