### PR TITLE
store result in variables for subsequent reuse

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -145,9 +145,9 @@ public final class Option implements Serializable {
             .of(new String[] { "result.format", "Output format to use for query results." });
     public static final Option RESULT_VAR = Option
             .of(new String[] { "result.var", "Unique variable name of the query result." });
-    public static final Option RESULT_REUSE = Option
-            .of(new String[] { "result.reuse", "Whether to reuse the result, only works when result.var is specified.",
-                    Constants.TRUE_EXPR, Constants.FALSE_EXPR });
+    public static final Option RESULT_REUSE = Option.of(new String[] { "result.reuse",
+            "Whether to reuse previous result by retrieving the variable from context, only works when result.var is specified.",
+            Constants.TRUE_EXPR, Constants.FALSE_EXPR });
     public static final Option RESULT_SCOPE = Option
             .of(new String[] { "result.scope", "Scope of the result, only works when result.var is specified.",
                     Constants.SCOPE_QUERY, Constants.SCOPE_THREAD, Constants.SCOPE_GLOBAL });

--- a/core/src/main/java/io/github/jdbcx/Result.java
+++ b/core/src/main/java/io/github/jdbcx/Result.java
@@ -482,6 +482,10 @@ public final class Result<T> implements AutoCloseable {
                 Utils.format("Cannot convert value from [%s] to [%s]", valueType, clazz));
     }
 
+    public int getFieldCount() {
+        return fields.size();
+    }
+
     public Class<?> type() {
         return valueType;
     }

--- a/core/src/test/java/io/github/jdbcx/ResultTest.java
+++ b/core/src/test/java/io/github/jdbcx/ResultTest.java
@@ -181,6 +181,15 @@ public class ResultTest {
     }
 
     @Test(groups = "unit")
+    public void testGetFieldCount() {
+        Assert.assertEquals(Result.of(Row.EMPTY).getFieldCount(), 0);
+        Assert.assertEquals(Result.of("123").getFieldCount(), 1);
+        Assert.assertEquals(Result.of(1L).getFieldCount(), 1);
+
+        Assert.assertEquals(Result.of(Arrays.asList(Field.of("a1"), Field.of("a2"))).getFieldCount(), 2);
+    }
+
+    @Test(groups = "unit")
     public void testRows() throws SQLException {
         Assert.assertThrows(IllegalArgumentException.class, () -> Result.of((Row) null));
 

--- a/driver/src/main/java/io/github/jdbcx/JdbcActivityListener.java
+++ b/driver/src/main/java/io/github/jdbcx/JdbcActivityListener.java
@@ -35,9 +35,7 @@ public interface JdbcActivityListener {
         return metaData;
     }
 
-    // onPrepare
-
-    default Result<?> onQuery(String query) throws SQLException {
+    default Result<?> onQuery(String query) throws SQLException { // NOSONAR
         return Result.of(query);
     }
 


### PR DESCRIPTION
This feature is particularly useful for change data capture (CDC).

```sql
-- assume you're on target database
{% var: batchSize=100 %}
{% db(result.var=c): select max(id) id, max(update_datetime) ts from target_table  %}
{% script(result.var=w): "${c.id}" == "" ? "" : " where id > ${c.id} and update_datetime > '${c.ts}'" %}
insert into target_table
{{ bridge.db.source:
select * from source_table ${w} order by id limit ${batchSize}
}}
```