### PR TITLE
add bridge extension along with table and values prefix

### DIFF
--- a/core/src/main/java/io/github/jdbcx/QueryContext.java
+++ b/core/src/main/java/io/github/jdbcx/QueryContext.java
@@ -29,8 +29,25 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class QueryContext implements AutoCloseable, Serializable {
     private static final long serialVersionUID = -7227092865499240252L;
 
+    /**
+     * Key for bridge configuration encapsulated in {@link Properties}.
+     */
+    public static final String KEY_BRIDGE = "bridge";
+    /**
+     * Key for {@link ConfigManager}.
+     */
     public static final String KEY_CONFIG = "config";
+    /**
+     * Key for function to get {@link java.sql.Connection}.
+     */
     public static final String KEY_CONNECTION = "connection";
+    /**
+     * Key for JDBC dialect.
+     */
+    public static final String KEY_DIALECT = "dialect";
+    /**
+     * Key for {@link VariableTag}.
+     */
     public static final String KEY_TAG = "tag";
 
     private static final QueryContext globalContext = new QueryContext(Constants.SCOPE_GLOBAL, null);

--- a/core/src/main/java/io/github/jdbcx/Version.java
+++ b/core/src/main/java/io/github/jdbcx/Version.java
@@ -129,7 +129,7 @@ public final class Version {
             builder.append('.').append(patch);
         }
         if (!additional.isEmpty()) {
-            builder.append(' ').append(additional);
+            builder.append(additional);
         }
         return builder.toString();
     }

--- a/core/src/main/java/io/github/jdbcx/format/AvroSerde.java
+++ b/core/src/main/java/io/github/jdbcx/format/AvroSerde.java
@@ -186,6 +186,27 @@ public class AvroSerde implements Serialization {
                 value = Utils.toEpochNanoSeconds(v.asDateTime(), v.getFactory().getZoneOffset())
                         / (f.scale() > 3 ? 1_000L : 1_000_000L);
                 break;
+            case TINYINT:
+                if (f.isSigned()) {
+                    value = v.asByte();
+                } else {
+                    value = v.asShort();
+                }
+                break;
+            case SMALLINT:
+                if (f.isSigned()) {
+                    value = v.asShort();
+                } else {
+                    value = v.asInt();
+                }
+                break;
+            case INTEGER:
+                if (f.isSigned()) {
+                    value = v.asInt();
+                } else {
+                    value = v.asLong();
+                }
+                break;
             case BIGINT:
                 if (f.isSigned()) {
                     value = v.asLong();

--- a/core/src/test/java/io/github/jdbcx/VersionTest.java
+++ b/core/src/test/java/io/github/jdbcx/VersionTest.java
@@ -48,27 +48,27 @@ public class VersionTest {
     public void testToString() {
         Version v = Version.of("0.3.2  (rev: 123) ");
         Assert.assertEquals(v.toString(), "Version 0.3.2 (rev: 123)");
-        Assert.assertEquals(v.toCompactString(), "0.3.2 (rev: 123)");
+        Assert.assertEquals(v.toCompactString(), "0.3.2(rev: 123)");
         Assert.assertEquals(v.toShortString(), "0.3.2");
 
         v = Version.of("0.0.2  (rev: 123) ");
         Assert.assertEquals(v.toString(), "Version 0.0.2 (rev: 123)");
-        Assert.assertEquals(v.toCompactString(), "0.0.2 (rev: 123)");
+        Assert.assertEquals(v.toCompactString(), "0.0.2(rev: 123)");
         Assert.assertEquals(v.toShortString(), "0.0.2");
 
         v = Version.of("1.0.0  (rev: 123) ");
         Assert.assertEquals(v.toString(), "Version 1.0.0 (rev: 123)");
-        Assert.assertEquals(v.toCompactString(), "1 (rev: 123)");
+        Assert.assertEquals(v.toCompactString(), "1(rev: 123)");
         Assert.assertEquals(v.toShortString(), "1");
 
         v = Version.of("1.1.0  (rev: 123) ");
         Assert.assertEquals(v.toString(), "Version 1.1.0 (rev: 123)");
-        Assert.assertEquals(v.toCompactString(), "1.1 (rev: 123)");
+        Assert.assertEquals(v.toCompactString(), "1.1(rev: 123)");
         Assert.assertEquals(v.toShortString(), "1.1");
 
         v = Version.of("1.0.1  (rev: 123) ");
         Assert.assertEquals(v.toString(), "Version 1.0.1 (rev: 123)");
-        Assert.assertEquals(v.toCompactString(), "1.0.1 (rev: 123)");
+        Assert.assertEquals(v.toCompactString(), "1.0.1(rev: 123)");
         Assert.assertEquals(v.toShortString(), "1.0.1");
     }
 }

--- a/driver/src/main/java/io/github/jdbcx/DriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/DriverExtension.java
@@ -35,6 +35,12 @@ import io.github.jdbcx.driver.DefaultDriverExtension;
 // query extension:
 // result extension
 public interface DriverExtension extends Comparable<DriverExtension> {
+    static final String PROPERTY_BRIDGE_URL = "url";
+    static final String PROPERTY_BRIDGE_TOKEN = "token";
+    static final String PROPERTY_PATH = "path";
+    static final String PROPERTY_PRODUCT = "product";
+    static final String PROPERTY_USER = "user";
+
     static final String DEFAULT_JDBC_TABLE_TYPE = "TABLE";
 
     static final List<Field> JDBC_TABLE_FIELDS = Collections
@@ -244,6 +250,16 @@ public interface DriverExtension extends Comparable<DriverExtension> {
      *         properties and content; false otherwise
      */
     default boolean supportsNoArguments() {
+        return false;
+    }
+
+    /**
+     * Whether this extension requires bridge context(e.g. current DB product, user,
+     * and bridge config etc.) or not.
+     *
+     * @return true if bridge context is required; false otherwise
+     */
+    default boolean requiresBridgeContext() {
         return false;
     }
 

--- a/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
+++ b/driver/src/main/java/io/github/jdbcx/JdbcDialect.java
@@ -67,6 +67,34 @@ public interface JdbcDialect {
         return Format.CSV;
     }
 
+    default String getEncodings(Compression serverCompress) {
+        final Compression defaultCompress;
+        if (serverCompress == null) {
+            return getPreferredCompression().encoding();
+        } else if (serverCompress == (defaultCompress = getPreferredCompression())) {
+            return serverCompress.encoding();
+        }
+        StringBuilder builder = new StringBuilder();
+        if (supports(serverCompress)) {
+            builder.append(serverCompress.encoding()).append(';');
+        }
+        return builder.append(defaultCompress.encoding()).toString();
+    }
+
+    default String getMimeTypes(Format serverFormat) {
+        final Format defaultFormat;
+        if (serverFormat == null) {
+            return getPreferredFormat().mimeType();
+        } else if (serverFormat == (defaultFormat = getPreferredFormat())) {
+            return serverFormat.mimeType();
+        }
+        StringBuilder builder = new StringBuilder();
+        if (supports(serverFormat)) {
+            builder.append(serverFormat.mimeType()).append(';');
+        }
+        return builder.append(defaultFormat.mimeType()).toString();
+    }
+
     default VariableTag getVariableTag() {
         return VariableTag.BRACE;
     }
@@ -82,7 +110,7 @@ public interface JdbcDialect {
      * shown below.
      * 
      * <pre>
-     * select * from {{ bridge.db.mysql1: select 1 }}
+     * select * from {{ table.db.mysql1: select 1 }}
      * </pre>
      * 
      * The inner query will be translated to

--- a/driver/src/main/java/io/github/jdbcx/QueryMode.java
+++ b/driver/src/main/java/io/github/jdbcx/QueryMode.java
@@ -15,6 +15,8 @@
  */
 package io.github.jdbcx;
 
+import java.util.Locale;
+
 public enum QueryMode {
     /**
      * Submits a query for later execution.
@@ -145,6 +147,6 @@ public enum QueryMode {
         } else {
             mode = fromPath(str, null);
         }
-        return mode != null ? mode : valueOf(str);
+        return mode != null ? mode : valueOf(str.toUpperCase(Locale.ROOT));
     }
 }

--- a/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
@@ -31,7 +31,8 @@ import io.github.jdbcx.Checker;
  */
 public final class ExecutableBlock {
     // reserved keyword
-    static final String KEYWORD_BRIDGE = "bridge";
+    static final String KEYWORD_TABLE = "table";
+    static final String KEYWORD_VALUES = "values";
 
     private final int index;
     private final String extension;
@@ -86,7 +87,7 @@ public final class ExecutableBlock {
     }
 
     public boolean useBridge() {
-        return KEYWORD_BRIDGE.equals(extension);
+        return KEYWORD_TABLE.equals(extension) || KEYWORD_VALUES.equals(extension);
     }
 
     @Override

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
@@ -228,13 +228,13 @@ public final class QueryParser {
     }
 
     static String[] extractBridgeBlock(String block, String extension, int beginIndex, int len) {
-        if (!ExecutableBlock.KEYWORD_BRIDGE.equals(extension)) {
+        if (!ExecutableBlock.KEYWORD_TABLE.equals(extension) && !ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
             return Constants.EMPTY_STRING_ARRAY;
         }
 
         for (int i = beginIndex; i < len; i++) {
             char ch = block.charAt(i);
-            if (ch == '.') {
+            if (ch == '.' || ch == ':') {
                 beginIndex = i + 1;
                 break;
             } else if (!Character.isWhitespace(ch)) {
@@ -242,7 +242,7 @@ public final class QueryParser {
                 break;
             }
         }
-        return new String[] { ExecutableBlock.KEYWORD_BRIDGE, block.substring(beginIndex) };
+        return new String[] { extension, block.substring(beginIndex) };
     }
 
     static String[] parseExecutableBlock(String block, VariableTag tag, Properties props) {
@@ -325,8 +325,9 @@ public final class QueryParser {
 
                     if (j == len) {
                         extension = block.substring(beginIndex, i);
-                        if (ExecutableBlock.KEYWORD_BRIDGE.equals(extension)) {
-                            return new String[] { ExecutableBlock.KEYWORD_BRIDGE, Constants.EMPTY_STRING };
+                        if (ExecutableBlock.KEYWORD_TABLE.equals(extension)
+                                || ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
+                            return new String[] { extension, Constants.EMPTY_STRING };
                         }
                         script = Constants.EMPTY_STRING;
                         break;
@@ -358,8 +359,9 @@ public final class QueryParser {
         if (script == null) {
             if (scope == 0) {
                 extension = block.substring(beginIndex);
-                if (ExecutableBlock.KEYWORD_BRIDGE.equals(extension)) {
-                    return new String[] { ExecutableBlock.KEYWORD_BRIDGE, Constants.EMPTY_STRING };
+                if (ExecutableBlock.KEYWORD_TABLE.equals(extension)
+                        || ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
+                    return new String[] { extension, Constants.EMPTY_STRING };
                 }
                 script = Constants.EMPTY_STRING;
             } else {

--- a/driver/src/main/java/io/github/jdbcx/driver/WrappedConnection.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/WrappedConnection.java
@@ -191,7 +191,7 @@ public class WrappedConnection implements ManagedConnection {
                     String val = Utils.applyVariables(entry.getValue().toString(), tag, p);
                     p.setProperty(key, val);
                 }
-                JdbcActivityListener cl = ext.createListener(context, manager.getConnection(), p); // NOSONAR
+                JdbcActivityListener cl = manager.createListener(ext, context, manager.getConnection(), p); // NOSONAR
                 if (block.hasOutput()) {
                     try {
                         parts[block.getIndex()] = ConnectionManager.normalize(ConnectionManager.convertTo(

--- a/driver/src/main/java/io/github/jdbcx/extension/BridgeDriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/extension/BridgeDriverExtension.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.extension;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.ConfigManager;
+import io.github.jdbcx.Constants;
+import io.github.jdbcx.DriverExtension;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.JdbcDialect;
+import io.github.jdbcx.Option;
+import io.github.jdbcx.QueryContext;
+import io.github.jdbcx.QueryMode;
+import io.github.jdbcx.RequestParameter;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.Utils;
+import io.github.jdbcx.executor.WebExecutor;
+import io.github.jdbcx.interpreter.WebInterpreter;
+
+public class BridgeDriverExtension implements DriverExtension {
+    static final Option OPTION_COMPRESSION = Option.of(new String[] { "compression", "Compression algorithm" });
+    static final Option OPTION_FORMAT = Option.of(new String[] { "format", "Data format" });
+    static final Option OPTION_QUERY_MODE = Option.of(new String[] { "mode", "Query mode" });
+    static final Option OPTION_PATH = Option.of(new String[] { DriverExtension.PROPERTY_PATH, "URL path" });
+    static final Option OPTION_URL = Option
+            .of(new String[] { DriverExtension.PROPERTY_BRIDGE_URL, "Bridge server URL" });
+    static final Option OPTION_TOKEN = Option
+            .of(new String[] { DriverExtension.PROPERTY_BRIDGE_TOKEN, "Secure token for accessing bridge server" });
+
+    static class ActivityListener extends AbstractActivityListener {
+        ActivityListener(QueryContext context, Properties config) {
+            super(new WebInterpreter(context, config), config);
+        }
+
+        String rewrite(String query) {
+            final int len;
+            if (query == null || (len = query.length()) == 0) {
+                return query;
+            }
+            final char escapeChar = '\\';
+            final char target = interpreter.getVariableTag().rightChar();
+            StringBuilder builder = new StringBuilder(len);
+            boolean escaped = false;
+            for (int i = 0; i < len; i++) {
+                char ch = query.charAt(i);
+                if (escaped) {
+                    if (ch != escapeChar && ch != target) {
+                        builder.append(escapeChar);
+                    }
+                    builder.append(ch);
+                    escaped = false;
+                } else if (ch == escapeChar) {
+                    escaped = true;
+                } else {
+                    builder.append(ch);
+                }
+            }
+            if (escaped) {
+                builder.append(escapeChar);
+            }
+            return builder.toString();
+        }
+
+        @Override
+        public Result<?> onQuery(String query) throws SQLException {
+            return super.onQuery(rewrite(query));
+        }
+
+        @Override
+        public String onQuery(PreparedStatement statement, String query) throws SQLException {
+            return super.onQuery(statement, rewrite(query));
+        }
+    }
+
+    /**
+     * Builds new configuration for {@link WebInterpreter} according to the given
+     * query context and configuration.
+     *
+     * @param context non-null query context with both bridge context and dialect
+     * @param config  non-null configuration
+     * @return non-null new configuration for {@link WebInterpreter}
+     */
+    static Properties build(QueryContext context, Properties config) {
+        final Properties props = new Properties(config);
+        final Properties bridgeCtx = (Properties) context.get(QueryContext.KEY_BRIDGE);
+        final JdbcDialect dialect = (JdbcDialect) context.get(QueryContext.KEY_DIALECT);
+
+        final String path = OPTION_PATH.getValue(config);
+        final String url = OPTION_URL.getValue(config);
+        if (!Checker.isNullOrEmpty(url)) { // URL takes priority
+            WebInterpreter.OPTION_URL_TEMPLATE.setValue(props, url);
+        } else if (!Checker.isNullOrEmpty(path)) { // and then path
+            StringBuilder builder = new StringBuilder(OPTION_URL.getValue(bridgeCtx));
+            int len = builder.length() - 1;
+            if (len < 0) { // should not happen, as bridge URL is never empty
+                builder.append(path);
+            } else if (builder.charAt(len) == '/') {
+                builder.append(path.charAt(0) == '/' ? path.substring(1) : path);
+            } else {
+                if (path.charAt(0) != '/') {
+                    builder.append('/');
+                }
+                builder.append(path);
+            }
+            WebInterpreter.OPTION_URL_TEMPLATE.setValue(props, builder.toString());
+        } else { // fall back to the default bridge server
+            WebInterpreter.OPTION_URL_TEMPLATE.setValue(props, OPTION_URL.getValue(bridgeCtx));
+        }
+
+        StringBuilder builder = new StringBuilder(WebExecutor.HEADER_USER_AGENT).append('=')
+                .append(Utils.escape(
+                        bridgeCtx == null ? Constants.PRODUCT_NAME
+                                : bridgeCtx.getProperty(DriverExtension.PROPERTY_PRODUCT, Constants.PRODUCT_NAME),
+                        ','));
+
+        // access token
+        String value = OPTION_TOKEN.getValue(config);
+        if (Checker.isNullOrEmpty(value)) {
+            value = OPTION_TOKEN.getValue(bridgeCtx);
+        }
+        if (!Checker.isNullOrEmpty(value)) {
+            WebInterpreter.OPTION_AUTH_BEARER_TOKEN.setValue(props, value);
+        }
+
+        // query user
+        value = bridgeCtx == null ? null : bridgeCtx.getProperty(DriverExtension.PROPERTY_USER);
+        if (!Checker.isNullOrEmpty(value)) {
+            builder.append(',').append(RequestParameter.USER.header()).append('=').append(Utils.escape(value, ','));
+        }
+
+        // query mode, might have been covered in URL/path
+        value = OPTION_QUERY_MODE.getValue(config);
+        if (!Checker.isNullOrEmpty(value)) {
+            builder.append(',').append(RequestParameter.MODE.header()).append('=')
+                    .append(Checker.isNullOrEmpty(value) ? QueryMode.ASYNC.code() : QueryMode.of(value).code());
+        }
+
+        // data format, might have been covered in URL/path
+        value = OPTION_FORMAT.getValue(config);
+        if (Checker.isNullOrEmpty(value)) {
+            value = Option.SERVER_FORMAT.getValue(bridgeCtx);
+        }
+        if (!Checker.isNullOrEmpty(value)) {
+            Format format = Format.fromFileExtension(value, null);
+            if (format == null) {
+                format = Format.valueOf(value.toUpperCase(Locale.ROOT));
+            }
+            builder.append(',').append(RequestParameter.FORMAT.header()).append('=')
+                    .append(dialect == null ? format.mimeType() : dialect.getMimeTypes(format));
+        }
+
+        // compression algorithm, might have been covered in URL/path
+        value = OPTION_COMPRESSION.getValue(config);
+        if (Checker.isNullOrEmpty(value)) {
+            value = Option.SERVER_COMPRESSION.getValue(bridgeCtx);
+        }
+        if (!Checker.isNullOrEmpty(value)) {
+            Compression compress = Compression.fromFileExtension(value, null);
+            if (compress == null) {
+                compress = Compression.valueOf(value.toUpperCase(Locale.ROOT));
+            }
+            builder.append(',').append(RequestParameter.COMPRESSION.header()).append('=')
+                    .append(dialect == null ? compress.encoding() : dialect.getEncodings(compress));
+        }
+
+        WebInterpreter.OPTION_REQUEST_HEADERS.setValue(props, builder.toString());
+        return props;
+    }
+
+    public static final List<Option> OPTIONS = Collections.unmodifiableList(Arrays.asList(Option.EXEC_ERROR,
+            Option.EXEC_TIMEOUT, OPTION_URL, OPTION_QUERY_MODE, OPTION_COMPRESSION, OPTION_FORMAT, OPTION_TOKEN,
+            WebExecutor.OPTION_CONNECT_TIMEOUT, WebExecutor.OPTION_PROXY, WebExecutor.OPTION_SOCKET_TIMEOUT,
+            WebInterpreter.OPTION_REQUEST_HEADERS));
+
+    @Override
+    public List<Option> getDefaultOptions() {
+        return OPTIONS;
+    }
+
+    @Override
+    public ActivityListener createListener(QueryContext context, Connection conn, Properties props) {
+        return new ActivityListener(context,
+                build(context, getConfig((ConfigManager) context.get(QueryContext.KEY_CONFIG), props)));
+    }
+
+    @Override
+    public String getDescription() {
+        return "Extension for accessing remote datasets via bridge server.";
+    }
+
+    @Override
+    public String getUsage() {
+        return "{{ bridge(url=http://127.0.0.1:8080/): select 1 }}";
+    }
+
+    @Override
+    public boolean requiresBridgeContext() {
+        return true;
+    }
+}

--- a/driver/src/main/resources/META-INF/services/io.github.jdbcx.DriverExtension
+++ b/driver/src/main/resources/META-INF/services/io.github.jdbcx.DriverExtension
@@ -1,4 +1,5 @@
 io.github.jdbcx.driver.HelpDriverExtension
+io.github.jdbcx.extension.BridgeDriverExtension
 io.github.jdbcx.extension.CodeQLDriverExtension
 io.github.jdbcx.extension.DbDriverExtension
 io.github.jdbcx.extension.PromptDriverExtension

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryBuilderTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryBuilderTest.java
@@ -22,64 +22,10 @@ import java.util.Properties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import io.github.jdbcx.Compression;
-import io.github.jdbcx.Format;
-import io.github.jdbcx.JdbcDialect;
-import io.github.jdbcx.Option;
 import io.github.jdbcx.QueryContext;
-import io.github.jdbcx.ResultMapper;
 import io.github.jdbcx.WrappedDriver;
 
 public class QueryBuilderTest {
-    static class TestJdbcDialect implements JdbcDialect {
-        @Override
-        public Compression getPreferredCompression() {
-            return Compression.ZSTD;
-        }
-
-        @Override
-        public Format getPreferredFormat() {
-            return Format.AVRO_JSON;
-        }
-
-        @Override
-        public boolean supports(Compression compress) {
-            return compress != null && compress != Compression.GZIP;
-        }
-
-        @Override
-        public boolean supports(Format format) {
-            return format != null && format != Format.PARQUET;
-        }
-
-        @Override
-        public ResultMapper getMapper() {
-            return null;
-        }
-    }
-
-    @Test(groups = { "unit" })
-    public void testGetEncodings() {
-        final TestJdbcDialect dialect = new TestJdbcDialect();
-        Assert.assertEquals(QueryBuilder.getEncodings(dialect, null), "zstd;identity");
-
-        Properties config = new Properties();
-        Assert.assertEquals(QueryBuilder.getEncodings(dialect, config), "zstd;identity");
-        Option.SERVER_COMPRESSION.setValue(config, "GZIP");
-        Assert.assertEquals(QueryBuilder.getEncodings(dialect, config), "zstd");
-    }
-
-    @Test(groups = { "unit" })
-    public void testGetMimeTypes() {
-        final TestJdbcDialect dialect = new TestJdbcDialect();
-        Assert.assertEquals(QueryBuilder.getMimeTypes(dialect, null), "application/vnd.apache.avro+json;text/csv");
-
-        Properties config = new Properties();
-        Assert.assertEquals(QueryBuilder.getMimeTypes(dialect, config), "application/vnd.apache.avro+json;text/csv");
-        Option.SERVER_FORMAT.setValue(config, "PARQUET");
-        Assert.assertEquals(QueryBuilder.getMimeTypes(dialect, config), "application/vnd.apache.avro+json");
-    }
-
     @Test(groups = { "unit" })
     public void testBuild() throws SQLException {
         String url = "jdbcx:sqlite::memory:";

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
@@ -421,24 +421,27 @@ public class QueryParserTest {
                         Arrays.asList(new ExecutableBlock(1, "var", props, "x=ch-dev", false),
                                 new ExecutableBlock(3, "web", expectedProps, "my request", true))));
 
-        // bridge
+        // remote table
         props.clear();
         expectedProps.clear();
-        Assert.assertEquals(QueryParser.parse("{{ bridge }}", VariableTag.BRACE, props),
+        Assert.assertEquals(QueryParser.parse("{{ table }}", VariableTag.BRACE, props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "bridge", props, "", true))));
-        Assert.assertEquals(QueryParser.parse("{{ bridge. }}", VariableTag.BRACE, props),
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "", true))));
+        Assert.assertEquals(QueryParser.parse("{{ table. }}", VariableTag.BRACE, props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "bridge", props, "", true))));
-        Assert.assertEquals(QueryParser.parse("{{ bridge() }}", VariableTag.BRACE, props),
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "", true))));
+        Assert.assertEquals(QueryParser.parse("{{ table: }}", VariableTag.BRACE, props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "bridge", props, "()", true))));
-        Assert.assertEquals(QueryParser.parse("{{ bridge. web() }}", VariableTag.BRACE, props),
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "", true))));
+        Assert.assertEquals(QueryParser.parse("{{ table() }}", VariableTag.BRACE, props),
                 new ParsedQuery(Arrays.asList("", ""),
-                        Arrays.asList(new ExecutableBlock(1, "bridge", props, "web()", true))));
-        Assert.assertEquals(QueryParser.parse("select {{ bridge.db.db1: select 1 }}", VariableTag.BRACE, props),
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "()", true))));
+        Assert.assertEquals(QueryParser.parse("{{ table. web() }}", VariableTag.BRACE, props),
+                new ParsedQuery(Arrays.asList("", ""),
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "web()", true))));
+        Assert.assertEquals(QueryParser.parse("select {{ table.db.db1: select 1 }}", VariableTag.BRACE, props),
                 new ParsedQuery(Arrays.asList("select ", ""),
-                        Arrays.asList(new ExecutableBlock(1, "bridge", props, "db.db1: select 1", true))));
+                        Arrays.asList(new ExecutableBlock(1, "table", props, "db.db1: select 1", true))));
     }
 
     @Test(groups = { "unit" })

--- a/driver/src/test/java/io/github/jdbcx/extension/BridgeDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/BridgeDriverExtensionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.extension;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Map.Entry;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Format;
+import io.github.jdbcx.JdbcDialect;
+import io.github.jdbcx.Option;
+import io.github.jdbcx.QueryContext;
+import io.github.jdbcx.QueryMode;
+import io.github.jdbcx.ResultMapper;
+import io.github.jdbcx.VariableTag;
+import io.github.jdbcx.interpreter.WebInterpreter;
+
+public class BridgeDriverExtensionTest {
+    static class TestJdbcDialect implements JdbcDialect {
+        @Override
+        public ResultMapper getMapper() {
+            return null;
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testBuild() {
+        Properties props = new Properties();
+        props.setProperty("_secret1_", "xxx");
+        props.setProperty("_secret2_", "***");
+
+        try (QueryContext context = QueryContext.newContext()) {
+            Properties newProps = BridgeDriverExtension.build(context, props);
+            for (Entry<Object, Object> e : props.entrySet()) {
+                Assert.assertEquals(newProps.getProperty((String) e.getKey()), e.getValue());
+            }
+            Assert.assertEquals(WebInterpreter.OPTION_URL_TEMPLATE.getValue(newProps), "");
+            Assert.assertEquals(WebInterpreter.OPTION_AUTH_BEARER_TOKEN.getValue(newProps), "");
+            Assert.assertEquals(WebInterpreter.OPTION_REQUEST_HEADERS.getValue(newProps),
+                    "User-Agent=JDBCX,accept=text/csv,accept-encoding=identity");
+
+            Properties bridgeCtx = new Properties();
+            context.put(QueryContext.KEY_BRIDGE, bridgeCtx);
+            context.put(QueryContext.KEY_DIALECT, new TestJdbcDialect());
+            BridgeDriverExtension.OPTION_URL.setValue(props, "http://my.server:9090/bridge/");
+            BridgeDriverExtension.OPTION_QUERY_MODE.setValue(props, QueryMode.MUTATION.name().toLowerCase(Locale.ROOT));
+            BridgeDriverExtension.OPTION_FORMAT.setValue(props, Format.ARROW_STREAM.fileExtension(false));
+            BridgeDriverExtension.OPTION_COMPRESSION.setValue(props, Compression.BROTLI.fileExtension(false));
+            BridgeDriverExtension.OPTION_TOKEN.setValue(props, "321321123123");
+            Option.TAG.setValue(props, VariableTag.SQUARE_BRACKET.name());
+            bridgeCtx.setProperty("product", "MyDatabase/0.1");
+            bridgeCtx.setProperty("user", "me");
+            newProps = BridgeDriverExtension.build(context, props);
+            for (Entry<Object, Object> e : props.entrySet()) {
+                Assert.assertEquals(newProps.getProperty((String) e.getKey()), e.getValue());
+            }
+            Assert.assertEquals(WebInterpreter.OPTION_URL_TEMPLATE.getValue(newProps), "http://my.server:9090/bridge/");
+            Assert.assertEquals(WebInterpreter.OPTION_AUTH_BEARER_TOKEN.getValue(newProps), "321321123123");
+            Assert.assertEquals(WebInterpreter.OPTION_REQUEST_HEADERS.getValue(newProps),
+                    "User-Agent=MyDatabase/0.1,x-query-user=me,x-query-mode=m,accept=application/vnd.apache.arrow.stream;text/csv,accept-encoding=br;identity");
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testCreateListener() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("_secret1_", "xxx");
+        props.setProperty("_secret2_", "***");
+        try (Connection conn = DriverManager.getConnection("jdbcx:db:sqlite::memory:", props);
+                QueryContext context = QueryContext.newContext()) {
+            BridgeDriverExtension ext = new BridgeDriverExtension();
+            Properties newProps = BridgeDriverExtension.build(context, props);
+            for (Entry<Object, Object> e : props.entrySet()) {
+                Assert.assertEquals(newProps.getProperty((String) e.getKey()), e.getValue());
+            }
+
+            Assert.assertEquals(newProps.getProperty("product"), null);
+            Assert.assertThrows(SQLWarning.class, () -> ext.createListener(context, conn, props).onQuery("select 1"));
+
+            props.setProperty("url", "http://localhost:8080/");
+            Assert.assertThrows(SQLException.class, () -> ext.createListener(context, conn, props).onQuery("select 1"));
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testQueryRewrite() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbcx:db:sqlite::memory:");
+                QueryContext context = QueryContext.newContext()) {
+            BridgeDriverExtension ext = new BridgeDriverExtension();
+            BridgeDriverExtension.ActivityListener listener = ext.createListener(context, conn, new Properties());
+
+            Assert.assertEquals(listener.rewrite(null), null);
+            Assert.assertEquals(listener.rewrite(""), "");
+            Assert.assertEquals(listener.rewrite("select 1"), "select 1");
+
+            Assert.assertEquals(listener.rewrite("\\select 1\\"), "\\select 1\\");
+            Assert.assertEquals(listener.rewrite("\\\\select 1\\\\"), "\\select 1\\");
+
+            Assert.assertEquals(listener.rewrite("{{select 1}}"), "{{select 1}}");
+            Assert.assertEquals(listener.rewrite("{{select 1\\}}"), "{{select 1}}");
+            Assert.assertEquals(listener.rewrite("{{select 1}\\}"), "{{select 1}}");
+            Assert.assertEquals(listener.rewrite("{\\{select 1}}"), "{\\{select 1}}");
+            Assert.assertEquals(listener.rewrite("{\\{selec\\t} 1}}"), "{\\{selec\\t} 1}}");
+        }
+    }
+}

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -304,7 +304,8 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
     }
 
     protected final void writeConfig(OutputStream out) throws IOException {
-        essentials.store(out, Utils.format("Bridge server %s configuration", Version.current().toShortString()));
+        essentials.store(out, Utils.format("%s bridge server %s configuration", Constants.PRODUCT_NAME,
+                Version.current().toShortString()));
     }
 
     protected final void writeMetrics(OutputStream out) throws IOException {
@@ -452,7 +453,7 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
                     path = path.substring(index + 1);
                 }
             } else {
-                defaultMode = QueryMode.SUBMIT;
+                defaultMode = null;
             }
         }
 
@@ -501,7 +502,13 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
         final String queryMode = RequestParameter.MODE.getValue(headers, params, Constants.EMPTY_STRING);
         final QueryMode mode;
         if (queryMode.isEmpty()) {
-            mode = Checker.isNullOrEmpty(qid) ? defaultMode : QueryMode.DIRECT;
+            if (defaultMode != null) {
+                mode = defaultMode;
+            } else if (Checker.isNullOrEmpty(qid)) {
+                mode = QueryMode.SUBMIT;
+            } else {
+                mode = QueryMode.DIRECT;
+            }
         } else {
             mode = QueryMode.of(queryMode);
         }

--- a/server/src/main/java/io/github/jdbcx/server/impl/JdkHttpServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/impl/JdkHttpServer.java
@@ -224,7 +224,8 @@ public final class JdkHttpServer extends BridgeServer implements HttpHandler {
     @Override
     public void start() {
         server.start();
-        log.info("Bridge server %s started: %s", Version.current().toCompactString(), baseUrl);
+        log.info("%s bridge server %s started at %s", Constants.PRODUCT_NAME, Version.current().toCompactString(),
+                baseUrl);
     }
 
     @Override

--- a/server/src/test/java/io/github/jdbcx/server/impl/JdkHttpServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/impl/JdkHttpServerTest.java
@@ -15,13 +15,8 @@
  */
 package io.github.jdbcx.server.impl;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.Properties;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,23 +47,6 @@ public class JdkHttpServerTest extends BaseBridgeServerTest {
 
     @Test(groups = { "integration" })
     public void testAny() throws Exception {
-        Properties props = new Properties();
-        // props.setProperty("jdbcx.base.dir", "target/test-classes/config");
-
-        try (Connection conn = DriverManager.getConnection("jdbcx:ch://" + getClickHouseServer(), props);
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("select * from {{ bridge.db.my-duckdb: select 1}}")) {
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertFalse(rs.next());
-        }
-
-        try (Connection conn = DriverManager.getConnection("jdbcx:duckdb:", props);
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("select * from {{ bridge.db.my-sqlite: select 1}}")) {
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertFalse(rs.next());
-        }
+        // nothing
     }
 }


### PR DESCRIPTION
* bridge extension
  ```sql
  select * from {{ bridge(path=async/unique-id.csv.gz): {{ db.mysql1: select * from mytable \}} }}
  ```
* table(was bridge) and values prefix
  ```sql
  -- same as above
  select * from {{ table.db.mysql1: select * from mytable }}
  
  -- same as: insert into table1 (...) values (...), (...), ...
  insert into table1 {{ values.db.mysql1: select * from mytable }}
  ```