### PR TITLE
support multi-results

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,9 +25,10 @@ This project includes:
   Apache Commons IO under Apache-2.0
   Apache Commons Lang under Apache-2.0
   Apache Groovy under The Apache Software License, Version 2.0
-  Apache Hadoop Common under Apache License, Version 2.0
-  Apache Hadoop MapReduce Core under Apache License, Version 2.0
+  Apache Hadoop Common under Apache-2.0
+  Apache Hadoop MapReduce Core under Apache-2.0
   Apache Hadoop shaded Guava under Apache License, Version 2.0
+  Apache Hadoop shaded Protobuf under Apache License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
@@ -40,19 +41,19 @@ This project includes:
   Arrow Memory - Core under Apache License, Version 2.0
   Arrow Memory - Unsafe under Apache License, Version 2.0
   Arrow Vectors under Apache License, Version 2.0
+  Bouncy Castle Provider under Bouncy Castle Licence
   brotli4j under Apache License 2.0
   BSON under The Apache License, Version 2.0
+  Byte Buddy (without dependencies) under Apache License, Version 2.0
   Caffeine cache under Apache License, Version 2.0
   Checker Qual under The MIT License
   ClickHouse JDBC Driver under The Apache Software License, Version 2.0
-  Commons Logging under The Apache Software License, Version 2.0
+  commons-compiler under BSD-3-Clause
   docker-java-api under The Apache Software License, Version 2.0
   docker-java-transport under The Apache Software License, Version 2.0
   docker-java-transport-zerodep under The Apache Software License, Version 2.0
   DuckDB JDBC Driver under MIT License
   Duct Tape under MIT
-  Eclipse Collections API under Eclipse Public License - v 1.0 or Eclipse Distribution License - v 1.0
-  Eclipse Collections Main Library under Eclipse Public License - v 1.0 or Eclipse Distribution License - v 1.0
   FlatBuffers Java API under Apache License V2.0
   Gson under Apache-2.0
   Hamcrest Core under New BSD License
@@ -62,6 +63,7 @@ This project includes:
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
+  janino under BSD-3-Clause
   Java Native Access under LGPL-2.1-or-later or Apache-2.0
   Java Native Access Platform under LGPL-2.1-or-later or Apache-2.0
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
@@ -71,6 +73,7 @@ This project includes:
   jdbcx-driver under The Apache Software License, Version 2.0
   jdbcx-server under The Apache Software License, Version 2.0
   JetBrains Java Annotations under The Apache Software License, Version 2.0
+  Jettison under Apache License, Version 2.0
   JMESPath Core under BSD 3-Clause
   JMESPath GSON under BSD 3-Clause
   jquery under MIT License
@@ -106,4 +109,3 @@ This project includes:
   Woodstox under The Apache License, Version 2.0
   XZ for Java under Public Domain
   zstd-jni under BSD 2-Clause License
-

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -450,11 +450,7 @@ public final class Utils {
         }
 
         try {
-            ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            if (loader == null) {
-                loader = clazz.getClassLoader();
-            }
-            Class<?> c = loader.loadClass(className);
+            Class<?> c = Class.forName(className);
             Constructor<?> constructor = null;
             try { // NOSONAR
                 constructor = c.getConstructor(argClasses);

--- a/core/src/main/java/io/github/jdbcx/executor/JdbcExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/JdbcExecutor.java
@@ -64,6 +64,12 @@ public class JdbcExecutor extends AbstractExecutor {
     static final String TYPE_QUERY = "query";
     static final String TYPE_UPDATE = "update";
 
+    static final void closeResultSet(ResultSet rs) throws SQLException {
+        if (rs != null) {
+            rs.close();
+        }
+    }
+
     static final long getUpdateCount(Statement stmt) throws SQLException {
         return getUpdateCount(stmt, false);
     }
@@ -123,9 +129,7 @@ public class JdbcExecutor extends AbstractExecutor {
 
         while (true) {
             if (stmt.getMoreResults(Statement.KEEP_CURRENT_RESULT)) {
-                if (rs != null) {
-                    rs.close();
-                }
+                closeResultSet(rs);
                 rs = stmt.getResultSet();
                 count = 0L;
             } else {
@@ -133,9 +137,7 @@ public class JdbcExecutor extends AbstractExecutor {
                 if (value == -1L) {
                     break;
                 }
-                if (rs != null) {
-                    rs.close();
-                }
+                closeResultSet(rs);
                 rs = null;
                 count = value;
             }

--- a/core/src/main/java/io/github/jdbcx/executor/jdbc/CombinedResultSet.java
+++ b/core/src/main/java/io/github/jdbcx/executor/jdbc/CombinedResultSet.java
@@ -143,6 +143,22 @@ public class CombinedResultSet extends AbstractResultSet {
         }
     }
 
+    /**
+     * Checks if the combined result set only contains null {@link ResultSet} or
+     * empty {@link CombinedResultSet}.
+     *
+     * @return true if it's empty; false otherwise
+     */
+    public boolean isEmpty() {
+        for (int i = 0, len = results.length; i < len; i++) {
+            ResultSet rs = results[i];
+            if (rs != null && (!(rs instanceof CombinedResultSet) || !((CombinedResultSet) rs).isEmpty())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public boolean next() throws SQLException {
         if (hasNext()) {

--- a/core/src/main/java/io/github/jdbcx/interpreter/JdbcInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/JdbcInterpreter.java
@@ -50,8 +50,9 @@ public class JdbcInterpreter extends AbstractInterpreter {
     public static final Option OPTION_URL = Option.of(new String[] { "url", "JDBC connection URL" });
     public static final Option OPTION_DIALECT = Option.of(new String[] { "dialect", "Dialect class name" });
     public static final Option OPTION_DRIVER = Option.of(new String[] { "driver", "JDBC driver class name" });
-    public static final List<Option> OPTIONS = Collections.unmodifiableList(Arrays.asList(Option.EXEC_ERROR,
-            ConfigManager.OPTION_MANAGED, Option.EXEC_TIMEOUT.update().defaultValue("30000").build()));
+    public static final List<Option> OPTIONS = Collections
+            .unmodifiableList(Arrays.asList(Option.EXEC_ERROR, JdbcExecutor.OPTION_RESULT, ConfigManager.OPTION_MANAGED,
+                    Option.EXEC_TIMEOUT.update().defaultValue("30000").build()));
 
     private final String defaultConnectionUrl;
     private final String defaultConnectionProps;

--- a/core/src/test/java/io/github/jdbcx/executor/JdbcExecutorTest.java
+++ b/core/src/test/java/io/github/jdbcx/executor/JdbcExecutorTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.executor;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.BaseIntegrationTest;
+
+public class JdbcExecutorTest extends BaseIntegrationTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        Assert.assertNotNull(new JdbcExecutor(null, null));
+        Assert.assertNotNull(new JdbcExecutor(null, new Properties()));
+    }
+
+    @Test(groups = { "integration" })
+    public void testMultiQueryResults() throws SQLException {
+        Properties props = new Properties();
+
+        final String query = "select 1; select 2 n union select 3 order by 1; select 4 n union select 5 union select 6 order by 1";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "?allowMultiQueries=true")) {
+            JdbcExecutor exec = new JdbcExecutor(null, props);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_QUERY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 4);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 5);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 6);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_QUERY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 4);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 5);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 6);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_QUERIES);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 3);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 4);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 5);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 6);
+                Assert.assertFalse(rs.next());
+            }
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_UPDATES);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_SUMMARY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertEquals(rs.getString(2), "query");
+                Assert.assertEquals(rs.getLong(3), 1L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertEquals(rs.getString(2), "query");
+                Assert.assertEquals(rs.getLong(3), 2L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 3);
+                Assert.assertEquals(rs.getString(2), "query");
+                Assert.assertEquals(rs.getLong(3), 3L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testMultiUpdateCounts() throws SQLException {
+        Properties props = new Properties();
+
+        final String query = "create table if not exists test_multi_update_counts(i INTEGER); insert into test_multi_update_counts values(1); "
+                + "insert into test_multi_update_counts values(2),(3); insert into test_multi_update_counts values(4),(5),(6)";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "/mysql?allowMultiQueries=true")) {
+            JdbcExecutor exec = new JdbcExecutor(null, props);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_QUERY);
+            Assert.assertEquals(((ResultSet) exec.execute(query, conn, props)).next(), false);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST);
+            Assert.assertEquals(exec.execute(query, conn, props), 3L);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_QUERY);
+            Assert.assertEquals(((ResultSet) exec.execute(query, conn, props)).next(), false);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 3L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_QUERIES);
+            Assert.assertEquals(((ResultSet) exec.execute(query, conn, props)).next(), false);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_UPDATES);
+            Assert.assertEquals(exec.execute(query, conn, props), 6L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_SUMMARY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 0L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 1L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 3);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 2L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 4);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 3L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testMultiMixedResults() throws SQLException {
+        Properties props = new Properties();
+
+        final String query = "create table if not exists test_multi_mixed_results(i INTEGER); select * from test_multi_mixed_results; "
+                + "insert into test_multi_mixed_results values(1),(2); select * from test_multi_mixed_results order by i; "
+                + "delete from test_multi_mixed_results";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "/mysql?allowMultiQueries=true")) {
+            JdbcExecutor exec = new JdbcExecutor(null, props);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_QUERY);
+            Assert.assertEquals(((ResultSet) exec.execute(query, conn, props)).next(), false);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_FIRST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 0L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST);
+            Assert.assertEquals(exec.execute(query, conn, props), 2L);
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_QUERY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertFalse(rs.next());
+            }
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_LAST_UPDATE);
+            Assert.assertEquals(exec.execute(query, conn, props), 2L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_QUERIES);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertFalse(rs.next());
+            }
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_MERGED_UPDATES);
+            Assert.assertEquals(exec.execute(query, conn, props), 4L);
+
+            JdbcExecutor.OPTION_RESULT.setValue(props, JdbcExecutor.RESULT_SUMMARY);
+            try (ResultSet rs = (ResultSet) exec.execute(query, conn, props)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 0L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertEquals(rs.getString(2), "query");
+                Assert.assertEquals(rs.getLong(3), 0L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 3);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 2L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 4);
+                Assert.assertEquals(rs.getString(2), "query");
+                Assert.assertEquals(rs.getLong(3), 2L);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 5);
+                Assert.assertEquals(rs.getString(2), "update");
+                Assert.assertEquals(rs.getLong(3), 2L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/executor/jdbc/CombinedResultSetTest.java
+++ b/core/src/test/java/io/github/jdbcx/executor/jdbc/CombinedResultSetTest.java
@@ -20,6 +20,9 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.testng.Assert;
@@ -48,6 +51,37 @@ public class CombinedResultSetTest extends BaseIntegrationTest {
                 { "jdbc:sqlite::memory:", "select 0 union select 1 union select 2 order by 1",
                         "select 3 union select 4 order by 1" },
         };
+    }
+
+    @Test(groups = { "unit" })
+    public void testIsEmpty() throws SQLException {
+        Assert.assertTrue(new CombinedResultSet().isEmpty());
+        Assert.assertTrue(new CombinedResultSet(new CombinedResultSet()).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(new CombinedResultSet(new CombinedResultSet())).isEmpty());
+
+        Assert.assertTrue(new CombinedResultSet((ResultSet) null).isEmpty());
+        Assert.assertTrue(new CombinedResultSet((ResultSet) null, null).isEmpty());
+
+        Assert.assertTrue(new CombinedResultSet((ResultSet[]) null).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(new ResultSet[0]).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(new ResultSet[1]).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(new ResultSet[2], null).isEmpty());
+
+        Assert.assertTrue(new CombinedResultSet((Collection<ResultSet>) null).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(Collections.emptyList()).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(Collections.singletonList((ResultSet) null)).isEmpty());
+        Assert.assertTrue(new CombinedResultSet(Arrays.asList((ResultSet) null, null)).isEmpty(), null);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("select 5")) {
+            Assert.assertFalse(new CombinedResultSet(rs).isEmpty());
+            Assert.assertFalse(new CombinedResultSet(null, rs).isEmpty());
+            Assert.assertFalse(new CombinedResultSet(rs, null).isEmpty());
+            Assert.assertFalse(new CombinedResultSet(null, rs, null).isEmpty());
+            Assert.assertFalse(
+                    new CombinedResultSet(null, new CombinedResultSet(Collections.singleton(rs)), null).isEmpty());
+        }
     }
 
     @Test(dataProvider = "numberQueries", groups = { "integration" })

--- a/driver/src/main/java/io/github/jdbcx/driver/WrappedStatement.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/WrappedStatement.java
@@ -60,7 +60,7 @@ public class WrappedStatement implements Statement {
         ResultSet rs = null;
         try {
             rs = stmt.getGeneratedKeys();
-        } catch (SQLFeatureNotSupportedException e) {
+        } catch (SQLFeatureNotSupportedException | UnsupportedOperationException e) {
             log.debug("Failed to get generated keys due to lack of support from the driver");
         }
         return rs;
@@ -96,26 +96,28 @@ public class WrappedStatement implements Statement {
 
         boolean result = false;
         int affectedRows = 0;
-        ResultSet[] rs = null;
+        final ResultSet[] rs = new ResultSet[2];
         try {
             int size = queries.size();
             if (size == 1) {
-                rs = new ResultSet[2];
                 String newQuery = queries.get(0);
                 log.debug("Executing [%s]: [%s]", this, newQuery);
                 if (result = stmt.execute(newQuery)) {
                     rs[1] = stmt.getResultSet();
+                    affectedRows = -1;
                 } else {
                     try { // NOSONAR
                         rs[0] = stmt.getGeneratedKeys();
-                    } catch (UnsupportedOperationException | SQLFeatureNotSupportedException e) {
+                    } catch (SQLException | UnsupportedOperationException e) {
                         // ignore
                     }
+                    affectedRows = stmt.getUpdateCount();
                 }
             } else {
-                ResultSet[] keys = new ResultSet[size];
-                ResultSet[] results = new ResultSet[size];
-                rs = new ResultSet[] { new CombinedResultSet(keys), new CombinedResultSet(results) }; // NOSONAR
+                final ResultSet[] keys = new ResultSet[size];
+                final ResultSet[] results = new ResultSet[size];
+                final CombinedResultSet keyRs = new CombinedResultSet(keys);
+                final CombinedResultSet resRs = new CombinedResultSet(results);
                 for (int i = 0; i < size; i++) {
                     String q = queries.get(i);
                     log.debug("Executing %d of %d: [%s]", i + 1, size, q);
@@ -124,6 +126,15 @@ public class WrappedStatement implements Statement {
                     } else {
                         affectedRows += callback.getUpdateCount();
                         keys[i] = callback.getGeneratedKeys();
+                    }
+                }
+                if (!keyRs.isEmpty()) {
+                    rs[0] = keyRs;
+                }
+                if (!resRs.isEmpty()) {
+                    rs[1] = resRs;
+                    if (affectedRows == 0) {
+                        affectedRows = -1;
                     }
                 }
             }
@@ -323,19 +334,24 @@ public class WrappedStatement implements Statement {
 
     @Override
     public ResultSet getResultSet() throws SQLException {
-        ResultSet rs = queryResult.getResultSet();
-        return rs != null ? rs : new WrappedResultSet(this, stmt.getResultSet());
+        return queryResult.getResultSet();
     }
 
     @Override
     public int getUpdateCount() throws SQLException {
         Integer i = queryResult.getUpdateCount();
-        return i != null ? i.intValue() : stmt.getUpdateCount();
+        return i != null ? i.intValue() : -1;
     }
 
     @Override
     public boolean getMoreResults() throws SQLException {
-        return stmt.getMoreResults();
+        // this might not work in all drivers: getMoreResults(CLOSE_CURRENT_RESULT)
+        final boolean hasMore = stmt.getMoreResults();
+        queryResult.reset();
+        // no need to update generated keys
+        queryResult.updateAll(null, hasMore ? new WrappedResultSet(this, stmt.getResultSet()) : null,
+                stmt.getUpdateCount());
+        return hasMore;
     }
 
     @Override
@@ -398,7 +414,12 @@ public class WrappedStatement implements Statement {
 
     @Override
     public boolean getMoreResults(int current) throws SQLException {
-        return stmt.getMoreResults(current);
+        final boolean hasMore = stmt.getMoreResults(current);
+        queryResult.reset();
+        // no need to update generated keys
+        queryResult.updateAll(null, hasMore ? new WrappedResultSet(this, stmt.getResultSet()) : null,
+                stmt.getUpdateCount());
+        return hasMore;
     }
 
     @Override

--- a/driver/src/main/java/io/github/jdbcx/driver/WrappedStatement.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/WrappedStatement.java
@@ -86,6 +86,7 @@ public class WrappedStatement implements Statement {
         return newStmt;
     }
 
+    @SuppressWarnings("resource")
     protected boolean execute(String query, ExecuteCallback callback) throws SQLException {
         queryResult.reset();
 
@@ -116,8 +117,8 @@ public class WrappedStatement implements Statement {
             } else {
                 final ResultSet[] keys = new ResultSet[size];
                 final ResultSet[] results = new ResultSet[size];
-                final CombinedResultSet keyRs = new CombinedResultSet(keys);
-                final CombinedResultSet resRs = new CombinedResultSet(results);
+                final CombinedResultSet keyRs = new CombinedResultSet(keys); // NOSONAR
+                final CombinedResultSet resRs = new CombinedResultSet(results); // NOSONAR
                 for (int i = 0; i < size; i++) {
                     String q = queries.get(i);
                     log.debug("Executing %d of %d: [%s]", i + 1, size, q);

--- a/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
+++ b/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
@@ -385,6 +385,28 @@ public class WrappedDriverTest extends BaseIntegrationTest {
     }
 
     @Test(groups = { "integration" })
+    public void testMultipleResults() throws SQLException {
+        Properties props = new Properties();
+        WrappedDriver d = new WrappedDriver();
+
+        final String query = "{{db(url='jdbc:mysql://root@" + getMySqlServer()
+                + "?allowMultiQueries=true', result=mergedQueries): select 1; select 2}}";
+        try (Connection conn = d.connect("jdbcx:", props); Statement stmt = conn.createStatement()) {
+            Assert.assertTrue(stmt.execute(query));
+
+            Assert.assertEquals(stmt.getUpdateCount(), -1);
+
+            try (ResultSet rs = stmt.getResultSet()) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 2);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
     public void testExecTimeout() throws SQLException {
         Properties props = new Properties();
         WrappedDriver d = new WrappedDriver();

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,10 @@
                         <artifactId>dnsjava</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>io.dropwizard.metrics</groupId>
                         <artifactId>metrics-core</artifactId>
                     </exclusion>


### PR DESCRIPTION
* fix the issue of returning non-null ResultSet when it should be
* support multi-results returned by Statement
* support selecting preferred result from generated ones
  ```sql
  {{ db(url=jdbc:mysql://root@localhost?allowMultiQueries=true, result=summary): select 1;select 2 }}
  ```

Will come up with a separate PR to support multiple queries for CLI and bridge server.