### PR TITLE
initial support of multi-queries in CLI

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,7 @@ jobs:
           distribution: "temurin"
           java-version: |
             8
-            17
+            21
           cache: "maven"
       - name: Setup Toolchain
         shell: bash
@@ -66,7 +66,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>
@@ -182,7 +182,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>21</version>
+                <version>17</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>
@@ -182,7 +182,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>21</version>
+                <version>17</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           docker build --build-arg JDBCX_VERSION=latest -t jdbcx:ci . \
           && docker run --rm jdbcx:ci 'jdbcx:sqlite::memory:' 'select {{script:1}}, {{shell:echo 2}}, {{prql:3}}'
 
-  test-jdk17-linux:
+  test-jdk21-linux:
     needs: compile
     strategy:
       matrix:
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    name: ${{ matrix.dist }} JDK 17 on ${{ matrix.os }}
+    name: ${{ matrix.dist }} JDK 21 on ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -111,11 +111,11 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 \
             origin pull/${{ github.event.inputs.pr }}/merge:merged-pr && git checkout merged-pr
         if: github.event.inputs.pr != ''
-      - name: Install JDK 17 and Maven
+      - name: Install JDK 21 and Maven
         uses: actions/setup-java@v3
         with:
           distribution: ${{ matrix.dist }}
-          java-version: 17
+          java-version: 21
           cache: "maven"
       - name: Setup Toolchain
         shell: bash
@@ -127,7 +127,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>
@@ -146,7 +146,7 @@ jobs:
             **/target/failsafe-reports
             **/target/surefire-reports
 
-  test-jdk17-osx-win:
+  test-jdk21-osx-win:
     needs: compile
     strategy:
       matrix:
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    name: ${{ matrix.dist }} JDK 17 on ${{ matrix.os }}
+    name: ${{ matrix.dist }} JDK 21 on ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -166,11 +166,11 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 \
             origin pull/${{ github.event.inputs.pr }}/merge:merged-pr && git checkout merged-pr
         if: github.event.inputs.pr != ''
-      - name: Install JDK 17 and Maven
+      - name: Install JDK 21 and Maven
         uses: actions/setup-java@v3
         with:
           distribution: ${{ matrix.dist }}
-          java-version: 17
+          java-version: 21
           cache: "maven"
       - name: Setup Toolchain
         shell: bash
@@ -182,7 +182,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: "temurin"
           java-version: |
             8
-            17
+            21
           cache: 'maven'
       - name: Setup Toolchain
         shell: bash
@@ -49,7 +49,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: "temurin"
           java-version: |
             8
-            17
+            21
           cache: "maven"
       - name: Setup Toolchain
         shell: bash
@@ -39,7 +39,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>17</version>
+                <version>21</version>
               </provides>
               <configuration>
                 <jdkHome>${{ env.JAVA_HOME }}</jdkHome>

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN chmod +x /*.sh \
 USER jdbcx
 
 RUN for ext in arrow aws azure fts httpfs json mysql parquet postgres sqlite vss; \
-    do ./openjdk/bin/java -Dverbose=true -DnoProperties=true -jar jdbcx.jar 'jdbcx:duckdb:' "INSTALL $ext" || true; done
+    do ./openjdk/bin/java -Dverbose=true -DnoProperties=true -cp jdbcx.jar io.github.jdbcx.Main 'jdbcx:duckdb:' "INSTALL $ext" || true; done
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/NOTICE
+++ b/NOTICE
@@ -44,7 +44,6 @@ This project includes:
   Bouncy Castle Provider under Bouncy Castle Licence
   brotli4j under Apache License 2.0
   BSON under The Apache License, Version 2.0
-  Byte Buddy (without dependencies) under Apache License, Version 2.0
   Caffeine cache under Apache License, Version 2.0
   Checker Qual under The MIT License
   ClickHouse JDBC Driver under The Apache Software License, Version 2.0
@@ -88,11 +87,11 @@ This project includes:
   MySQL Connector/J under The GNU General Public License, v2 with Universal FOSS Exception, v1.0
   org.brotli:dec under MIT License
   PostgreSQL JDBC Driver under BSD-2-Clause
-  Prometheus Java Simpleclient under The Apache Software License, Version 2.0
-  Prometheus Java Simpleclient Common under The Apache Software License, Version 2.0
-  Prometheus Java Span Context Supplier - Common under The Apache Software License, Version 2.0
-  Prometheus Java Span Context Supplier - OpenTelemetry under The Apache Software License, Version 2.0
-  Prometheus Java Span Context Supplier - OpenTelemetry Agent under The Apache Software License, Version 2.0
+  Prometheus Metrics Config under The Apache Software License, Version 2.0
+  Prometheus Metrics Core under The Apache Software License, Version 2.0
+  Prometheus Metrics Exposition Formats under The Apache Software License, Version 2.0
+  Prometheus Metrics Model under The Apache Software License, Version 2.0
+  Prometheus Metrics Tracer Common under The Apache Software License, Version 2.0
   Protocol Buffers [Core] under BSD-3-Clause
   rhino under Mozilla Public License, Version 2.0
   rhino-engine under Mozilla Public License, Version 2.0

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -152,10 +152,11 @@ public final class Utils {
             final String pattern;
             if (index != -1) {
                 dir = getPath(pathOrPattern.substring(0, index), true);
-                pattern = dir.resolve(pathOrPattern.substring(index + 1)).toString();
+                pattern = new StringBuilder(dir.toString()).append(File.separatorChar)
+                        .append(pathOrPattern.substring(index + 1)).toString();
             } else {
                 dir = Paths.get(Constants.CURRENT_DIR);
-                pattern = dir.resolve(pathOrPattern).toString();
+                pattern = new StringBuilder(dir.toString()).append(File.separatorChar).append(pathOrPattern).toString();
             }
 
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher(

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -154,7 +154,7 @@ public final class Utils {
                 dir = getPath(pathOrPattern.substring(0, index), true);
                 pattern = dir.resolve(pathOrPattern.substring(index + 1)).toString();
             } else {
-                dir = Path.of(Constants.CURRENT_DIR);
+                dir = Paths.get(Constants.CURRENT_DIR);
                 pattern = dir.resolve(pathOrPattern).toString();
             }
 

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -177,7 +177,7 @@ public final class Utils {
                 if (Files.isDirectory(path)) {
                     try (Stream<Path> s = Files.list(path)) {
                         list.addAll(s.filter(p -> Files.isRegularFile(p)
-                                && (normalizedFileExt.isEmpty() || p.endsWith(normalizedFileExt))).sorted()
+                                && (normalizedFileExt.isEmpty() || p.toString().endsWith(normalizedFileExt))).sorted()
                                 .collect(Collectors.toList()));
                     }
                 } else {

--- a/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/WebExecutor.java
@@ -68,7 +68,6 @@ public class WebExecutor extends AbstractExecutor {
                     "Connect timeout in milliseconds, a negative number or zero disables timeout", "5000" });
     public static final Option OPTION_FOLLOW_REDIRECT = Option
             .of(new String[] { "follow.redirect", "Whether follow redirect or not", Constants.TRUE_EXPR });
-    public static final Option OPTION_PROXY = Option.of(new String[] { "proxy", "Proxy server address" });
     public static final Option OPTION_SOCKET_TIMEOUT = Option
             .of(new String[] { "socket.timeout",
                     "Socket timeout in milliseconds, a negative number or zero disables timeout", "30000" });
@@ -118,7 +117,7 @@ public class WebExecutor extends AbstractExecutor {
 
     protected Proxy getProxy(Properties config) throws UnknownHostException {
         final Proxy p;
-        String proxy = OPTION_PROXY.getValue(config, defaultProxy);
+        String proxy = Option.PROXY.getValue(config, defaultProxy);
         if (Checker.isNullOrBlank(proxy)) {
             p = Proxy.NO_PROXY;
         } else {
@@ -172,7 +171,7 @@ public class WebExecutor extends AbstractExecutor {
         this.defaultConnectTimeout = OPTION_CONNECT_TIMEOUT.getValue(props);
         this.defaultFollowRedirect = OPTION_FOLLOW_REDIRECT.getValue(props);
         this.defaultSocketTimeout = OPTION_SOCKET_TIMEOUT.getValue(props, String.valueOf(defaultTimeout));
-        this.defaultProxy = OPTION_PROXY.getValue(props);
+        this.defaultProxy = Option.PROXY.getValue(props);
     }
 
     public HttpURLConnection openConnection(URL url, Properties config, Map<?, ?> headers) throws IOException {

--- a/core/src/main/java/io/github/jdbcx/interpreter/WebInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/WebInterpreter.java
@@ -77,8 +77,7 @@ public class WebInterpreter extends AbstractInterpreter {
                     Arrays.asList(Option.EXEC_ERROR, OPTION_BASE_URL, OPTION_URL_TEMPLATE, OPTION_REQUEST_HEADERS,
                             OPTION_REQUEST_TEMPLATE, OPTION_REQUEST_TEMPLATE_FILE, OPTION_REQUEST_ESCAPE_CHAR,
                             OPTION_REQUEST_ENCODE, OPTION_REQUEST_ESCAPE_TARGET, WebExecutor.OPTION_CONNECT_TIMEOUT,
-                            WebExecutor.OPTION_FOLLOW_REDIRECT, WebExecutor.OPTION_PROXY,
-                            WebExecutor.OPTION_SOCKET_TIMEOUT));
+                            WebExecutor.OPTION_FOLLOW_REDIRECT, Option.PROXY, WebExecutor.OPTION_SOCKET_TIMEOUT));
 
     private static final List<Field> dryRunFields = Collections.unmodifiableList(Arrays.asList(
             Field.of("url"), Field.of("method"), Field.of("request"), Field.of("connect_timeout_ms", JDBCType.BIGINT),

--- a/core/src/test/java/io/github/jdbcx/UtilsTest.java
+++ b/core/src/test/java/io/github/jdbcx/UtilsTest.java
@@ -138,6 +138,23 @@ public class UtilsTest {
         Assert.assertEquals(Utils.createInstance(List.class, "java.util.LinkedList", new ArrayList<>()).getClass(),
                 LinkedList.class);
     }
+    
+    @Test(groups = "unit")
+    public void testFindFiles() throws IOException {
+        Assert.assertEquals(Utils.findFiles(null, null), Collections.emptyList());
+        Assert.assertEquals(Utils.findFiles("", ""), Collections.emptyList());
+        Assert.assertEquals(Utils.findFiles("nothing", null), Collections.emptyList());
+        Assert.assertEquals(Utils.findFiles("*nothing", null), Collections.emptyList());
+        Assert.assertEquals(Utils.findFiles("n?thing", null), Collections.emptyList());
+        Assert.assertEquals(Utils.findFiles("target/classes/META-INF", ".x"), Collections.emptyList());
+
+        Assert.assertEquals(Utils.findFiles("pom*", null), Collections.singletonList(Utils.getPath("pom.xml", true)));
+        Assert.assertEquals(Utils.findFiles("target/test-classes/docker-*", ".yml"),
+                Collections.singletonList(Utils.getPath("target/test-classes/docker-compose.yml", true)));
+        Assert.assertEquals(Utils.findFiles("target/classes/META-INF", ""),
+                Arrays.asList(Utils.getPath("target/classes/META-INF/LICENSE", true),
+                        Utils.getPath("target/classes/META-INF/NOTICE", true)));
+    }
 
     @Test(groups = "unit")
     public void testToPrimitiveType() {

--- a/core/src/test/java/io/github/jdbcx/executor/WebExecutorTest.java
+++ b/core/src/test/java/io/github/jdbcx/executor/WebExecutorTest.java
@@ -37,7 +37,7 @@ public class WebExecutorTest extends BaseIntegrationTest {
         Assert.assertEquals(executor.getDefaultSocketTimeout(),
                 Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
         Assert.assertEquals(executor.getDefaultTimeout(), Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
-        Assert.assertEquals(executor.getDefaultProxy(), WebExecutor.OPTION_PROXY.getDefaultValue());
+        Assert.assertEquals(executor.getDefaultProxy(), Option.PROXY.getDefaultValue());
 
         Properties props = new Properties();
         Assert.assertNotNull(executor = new WebExecutor(null, props));
@@ -46,7 +46,7 @@ public class WebExecutorTest extends BaseIntegrationTest {
         Assert.assertEquals(executor.getDefaultSocketTimeout(),
                 Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
         Assert.assertEquals(executor.getDefaultTimeout(), Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
-        Assert.assertEquals(executor.getDefaultProxy(), WebExecutor.OPTION_PROXY.getDefaultValue());
+        Assert.assertEquals(executor.getDefaultProxy(), Option.PROXY.getDefaultValue());
 
         WebExecutor.OPTION_SOCKET_TIMEOUT.setValue(props, "30001");
         Assert.assertNotNull(executor = new WebExecutor(null, props));
@@ -54,23 +54,23 @@ public class WebExecutorTest extends BaseIntegrationTest {
                 Integer.parseInt(WebExecutor.OPTION_CONNECT_TIMEOUT.getDefaultValue()));
         Assert.assertEquals(executor.getDefaultSocketTimeout(), 30001);
         Assert.assertEquals(executor.getDefaultTimeout(), Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
-        Assert.assertEquals(executor.getDefaultProxy(), WebExecutor.OPTION_PROXY.getDefaultValue());
+        Assert.assertEquals(executor.getDefaultProxy(), Option.PROXY.getDefaultValue());
 
         WebExecutor.OPTION_CONNECT_TIMEOUT.setValue(props, "1234");
         Assert.assertNotNull(executor = new WebExecutor(null, props));
         Assert.assertEquals(executor.getDefaultConnectTimeout(), 1234);
         Assert.assertEquals(executor.getDefaultSocketTimeout(), 30001);
         Assert.assertEquals(executor.getDefaultTimeout(), Integer.parseInt(Option.EXEC_TIMEOUT.getDefaultValue()));
-        Assert.assertEquals(executor.getDefaultProxy(), WebExecutor.OPTION_PROXY.getDefaultValue());
+        Assert.assertEquals(executor.getDefaultProxy(), Option.PROXY.getDefaultValue());
 
         Option.EXEC_TIMEOUT.setValue(props, "999999");
         Assert.assertNotNull(executor = new WebExecutor(null, props));
         Assert.assertEquals(executor.getDefaultConnectTimeout(), 1234);
         Assert.assertEquals(executor.getDefaultSocketTimeout(), 30001);
         Assert.assertEquals(executor.getDefaultTimeout(), 999999);
-        Assert.assertEquals(executor.getDefaultProxy(), WebExecutor.OPTION_PROXY.getDefaultValue());
+        Assert.assertEquals(executor.getDefaultProxy(), Option.PROXY.getDefaultValue());
 
-        WebExecutor.OPTION_PROXY.setValue(props, "socks5h://4.3.2.1:1234");
+        Option.PROXY.setValue(props, "socks5h://4.3.2.1:1234");
         Assert.assertNotNull(executor = new WebExecutor(null, props));
         Assert.assertEquals(executor.getDefaultConnectTimeout(), 1234);
         Assert.assertEquals(executor.getDefaultSocketTimeout(), 30001);
@@ -85,39 +85,39 @@ public class WebExecutorTest extends BaseIntegrationTest {
         Assert.assertEquals(new WebExecutor(null, props).getProxy(null), Proxy.NO_PROXY);
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props), Proxy.NO_PROXY);
 
-        WebExecutor.OPTION_PROXY.setValue(props, "");
+        Option.PROXY.setValue(props, "");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props), Proxy.NO_PROXY);
 
-        WebExecutor.OPTION_PROXY.setValue(props, ":");
+        Option.PROXY.setValue(props, ":");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(WebExecutor.DEFAULT_PROXY_TYPE, InetSocketAddress
                         .createUnresolved(WebExecutor.DEFAULT_PROXY_HOST, WebExecutor.DEFAULT_PROXY_PORT)));
-        WebExecutor.OPTION_PROXY.setValue(props, ":8989");
+        Option.PROXY.setValue(props, ":8989");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(WebExecutor.DEFAULT_PROXY_TYPE,
                         InetSocketAddress.createUnresolved(WebExecutor.DEFAULT_PROXY_HOST, 8989)));
-        WebExecutor.OPTION_PROXY.setValue(props, "-$-"); // authority
+        Option.PROXY.setValue(props, "-$-"); // authority
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(WebExecutor.DEFAULT_PROXY_TYPE, InetSocketAddress
                         .createUnresolved(WebExecutor.DEFAULT_PROXY_HOST, WebExecutor.DEFAULT_PROXY_PORT)));
-        WebExecutor.OPTION_PROXY.setValue(props, "www.test.com:");
+        Option.PROXY.setValue(props, "www.test.com:");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(WebExecutor.DEFAULT_PROXY_TYPE,
                         InetSocketAddress.createUnresolved("www.test.com", WebExecutor.DEFAULT_PROXY_PORT)));
-        WebExecutor.OPTION_PROXY.setValue(props, "www.test.com:8989");
+        Option.PROXY.setValue(props, "www.test.com:8989");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(WebExecutor.DEFAULT_PROXY_TYPE,
                         InetSocketAddress.createUnresolved("www.test.com", 8989)));
 
-        WebExecutor.OPTION_PROXY.setValue(props, "http://www.test.com");
+        Option.PROXY.setValue(props, "http://www.test.com");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(Proxy.Type.HTTP,
                         InetSocketAddress.createUnresolved("www.test.com", WebExecutor.DEFAULT_PROXY_PORT)));
-        WebExecutor.OPTION_PROXY.setValue(props, "https://www.test.com");
+        Option.PROXY.setValue(props, "https://www.test.com");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(Proxy.Type.HTTP,
                         InetSocketAddress.createUnresolved("www.test.com", WebExecutor.DEFAULT_PROXY_PORT)));
-        WebExecutor.OPTION_PROXY.setValue(props, "socks5h://4.3.2.1:1234");
+        Option.PROXY.setValue(props, "socks5h://4.3.2.1:1234");
         Assert.assertEquals(new WebExecutor(null, props).getProxy(props),
                 new Proxy(Proxy.Type.SOCKS, InetSocketAddress.createUnresolved("4.3.2.1", 1234)));
     }
@@ -131,14 +131,14 @@ public class WebExecutorTest extends BaseIntegrationTest {
                 "Ok.\n");
         Assert.assertEquals(
                 Stream.readAllAsString(new WebExecutor(null, null)
-                        .get(new URL("http://default@" + address + "?query=select+7"), props, null)),
+                        .get(new URL("http://default@" + address + "/?query=select+7"), props, null)),
                 "7\n");
 
-        Option.PROXY.setValue(props, getProxyServer());
-        Assert.assertEquals(
-                Stream.readAllAsString(new WebExecutor(null, null).get(
-                        new URL("http://" + getDeclaredClickHouseServer() + "?query=select+1"), props, null)),
-                "1\n");
+        // Option.PROXY.setValue(props, getProxyServer());
+        // Assert.assertEquals(
+        //         Stream.readAllAsString(new WebExecutor(null, null).get(
+        //                 new URL("http://" + getDeclaredClickHouseServer() + "/?query=select+1"), props, null)),
+        //         "1\n");
     }
 
     @Test(groups = "integration")

--- a/core/src/test/java/io/github/jdbcx/executor/WebExecutorTest.java
+++ b/core/src/test/java/io/github/jdbcx/executor/WebExecutorTest.java
@@ -134,11 +134,11 @@ public class WebExecutorTest extends BaseIntegrationTest {
                         .get(new URL("http://default@" + address + "/?query=select+7"), props, null)),
                 "7\n");
 
-        // Option.PROXY.setValue(props, getProxyServer());
-        // Assert.assertEquals(
-        //         Stream.readAllAsString(new WebExecutor(null, null).get(
-        //                 new URL("http://" + getDeclaredClickHouseServer() + "/?query=select+1"), props, null)),
-        //         "1\n");
+        Option.PROXY.setValue(props, getProxyServer());
+        Assert.assertEquals(
+                Stream.readAllAsString(new WebExecutor(null, null).get(
+                        new URL("http://" + getDeclaredClickHouseServer() + "/?query=select+1"), props, null)),
+                "1\n");
     }
 
     @Test(groups = "integration")

--- a/core/src/test/java/io/github/jdbcx/format/ParquetSerdeTest.java
+++ b/core/src/test/java/io/github/jdbcx/format/ParquetSerdeTest.java
@@ -30,7 +30,7 @@ public class ParquetSerdeTest {
 
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             serde.serialize(Result.of("123"), out);
-            Assert.assertEquals(out.toByteArray().length, 452);
+            Assert.assertEquals(out.toByteArray().length, 474);
         }
     }
 }

--- a/core/src/test/resources/docker-compose.yml
+++ b/core/src/test/resources/docker-compose.yml
@@ -23,8 +23,7 @@ postgresql:
 
 # https://hub.docker.com/r/clickhouse/clickhouse-server/
 clickhouse:
-  # 24.3 has problem working behind the proxy
-  image: clickhouse/clickhouse-server:23.8
+  image: clickhouse/clickhouse-server:24.3
   links:
     - mysql
     - postgresql
@@ -39,8 +38,6 @@ flightsql:
 
 # https://github.com/Shopify/toxiproxy/pkgs/container/toxiproxy
 toxiproxy:
-  # 2.9.0 will somehow end up with the following error on GitHub CI:
-  # Timed out waiting for container port to open (localhost ports: [32769, 32770] should be listening)
-  image: zhicwu/toxiproxy:2.8.0
+  image: zhicwu/toxiproxy:2.9.0
   links:
     - clickhouse

--- a/core/src/test/resources/docker-compose.yml
+++ b/core/src/test/resources/docker-compose.yml
@@ -38,6 +38,8 @@ flightsql:
 
 # https://github.com/Shopify/toxiproxy/pkgs/container/toxiproxy
 toxiproxy:
-  image: zhicwu/toxiproxy:2.9.0
+  # 2.9.0 will somehow end up with the following error on GitHub CI:
+  # Timed out waiting for container port to open (localhost ports: [32769, 32770] should be listening)
+  image: zhicwu/toxiproxy:2.8.0
   links:
     - clickhouse

--- a/core/src/test/resources/docker-compose.yml
+++ b/core/src/test/resources/docker-compose.yml
@@ -23,7 +23,8 @@ postgresql:
 
 # https://hub.docker.com/r/clickhouse/clickhouse-server/
 clickhouse:
-  image: clickhouse/clickhouse-server:24.3
+  # 24.3 has problem working behind the proxy
+  image: clickhouse/clickhouse-server:23.8
   links:
     - mysql
     - postgresql

--- a/docker/app/.jdbcx/config.properties
+++ b/docker/app/.jdbcx/config.properties
@@ -27,5 +27,18 @@ jdbcx.prql.compile.options=--hide-signature-comment,--no-format
 
 # use a DNS or IP address that is accessible externally
 #jdbcx.server.url=http://server.dns.or.ip:8080/
+
+#jdbcx.server.backlog=0
+#jdbcx.server.threads=0
+
+# up to 10k queries in cache
+#server.request.limit=10000
+# 10 seconds before removing submitted query from cache
+#server.request.timeout=10000
+
 # prefer to throw error in server mode
 #jdbcx.db.exec.error=throw
+
+# prefer to use the last result when there's multiple ones
+# change to lastUpdate if the underlying JDBC driver does not support multi-results
+#jdbcx.db.result=last

--- a/driver/README.md
+++ b/driver/README.md
@@ -87,8 +87,8 @@ wget https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.45.1.0/sqlite-jdbc-
     https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.12/slf4j-simple-2.0.12.jar
 
 # Download JavaScript engine
-wget https://repo1.maven.org/maven2/org/mozilla/rhino/1.7.14/rhino-1.7.14.jar \
-    https://repo1.maven.org/maven2/org/mozilla/rhino-engine/1.7.14/rhino-engine-1.7.14.jar
+wget https://repo1.maven.org/maven2/org/mozilla/rhino/1.7.15/rhino-1.7.15.jar \
+    https://repo1.maven.org/maven2/org/mozilla/rhino-engine/1.7.15/rhino-engine-1.7.15.jar
 
 # SQL
 java -Djdbcx.custom.classpath=. -jar jdbcx.jar 'jdbcx:sqlite::memory:' 'select 1'

--- a/driver/src/main/java/io/github/jdbcx/Main.java
+++ b/driver/src/main/java/io/github/jdbcx/Main.java
@@ -337,7 +337,7 @@ public final class Main {
         boolean failed = false;
         do {
             if (tasks <= 1) {
-                failed = executeQueries(url, noProperties, validationTimeout, validationQuery, queries, outputFormat,
+                failed = !executeQueries(url, noProperties, validationTimeout, validationQuery, queries, outputFormat,
                         null, verbose);
             } else {
                 final AtomicBoolean failedRef = new AtomicBoolean(failed);

--- a/driver/src/main/java/io/github/jdbcx/Main.java
+++ b/driver/src/main/java/io/github/jdbcx/Main.java
@@ -370,7 +370,7 @@ public final class Main {
                                 Thread.currentThread().interrupt();
                             } catch (CancellationException | ExecutionException e) {
                                 cancel = true;
-                                e.printStackTrace();
+                                e.printStackTrace(); // NOSONAR
                             }
                         }
                     }

--- a/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
+++ b/driver/src/main/java/io/github/jdbcx/dialect/ClickHouseMapper.java
@@ -251,8 +251,7 @@ public class ClickHouseMapper implements ResultMapper {
         builder.append(',').append(toClickHouseDataFormat(format));
         final boolean hasFormat = format != null;
         final Field[] fields;
-        if ((!hasFormat || !format.supportsSchema()) && result != null
-                && (fields = result.fields().toArray(new Field[0])).length > 0) {
+        if (result != null && (fields = result.fields().toArray(new Field[0])).length > 0) {
             builder.append(EXPR_PART).append(Utils.escape(toColumnDefinition(fields), '\'', '\\')).append('\'');
         }
         List<String> parts = new ArrayList<>(2);

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
@@ -543,7 +543,7 @@ public final class QueryParser {
                     } else {
                         builder.append(ch).append(nextChar);
                         log.debug("Executable block starts with \"%s\" at %d but missing \"%s\"", tag.functionLeft(),
-                                tag.functionRight(), i - 1);
+                                i - 1, tag.functionRight());
                     }
                 } else if (nextChar == procChar && !escaped) { // executable block: {% ... %}
                     int index = indexOf(query, i + 1, tag.procedureRight(), escapeChar);
@@ -566,7 +566,7 @@ public final class QueryParser {
                     } else {
                         builder.append(ch);
                         log.debug("Executable block starts with \"%s\" at %d but missing \"%s\"", tag.procedureLeft(),
-                                tag.procedureRight(), i - 1);
+                                i - 1, tag.procedureRight());
                     }
                 } else {
                     builder.append(ch).append(nextChar);

--- a/driver/src/main/java/io/github/jdbcx/extension/BridgeDriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/extension/BridgeDriverExtension.java
@@ -234,7 +234,7 @@ public class BridgeDriverExtension implements DriverExtension {
 
     public static final List<Option> OPTIONS = Collections.unmodifiableList(Arrays.asList(Option.EXEC_ERROR,
             Option.EXEC_TIMEOUT, OPTION_URL, OPTION_QUERY_MODE, OPTION_COMPRESSION, OPTION_FORMAT, OPTION_TOKEN,
-            WebExecutor.OPTION_CONNECT_TIMEOUT, WebExecutor.OPTION_PROXY, WebExecutor.OPTION_SOCKET_TIMEOUT,
+            WebExecutor.OPTION_CONNECT_TIMEOUT, Option.PROXY, WebExecutor.OPTION_SOCKET_TIMEOUT,
             WebInterpreter.OPTION_REQUEST_HEADERS));
 
     @Override

--- a/driver/src/test/java/io/github/jdbcx/MainTest.java
+++ b/driver/src/test/java/io/github/jdbcx/MainTest.java
@@ -38,7 +38,7 @@ public class MainTest {
         return result.toArray(new String[0][2]);
     }
 
-    @Test(groups = { "unit" })
+    @Test(groups = { "private" })
     public void testCloseConnection() throws SQLException {
         Main.closeQuietly(null);
         Main.closeQuietly(new ByteArrayInputStream(new byte[1]));
@@ -50,7 +50,7 @@ public class MainTest {
         }
     }
 
-    @Test(groups = { "unit" })
+    @Test(groups = { "private" })
     public void testGetOrCreateConnection() throws SQLException {
         Assert.assertNull(Main.getOrCreateConnection(null, null, null, -1, null, false));
         Assert.assertNull(Main.getOrCreateConnection(null, null, null, 0, null, true));
@@ -120,7 +120,7 @@ public class MainTest {
                 new String[][] { { "n1", "q1" }, { "n3", "q3" }, { "n2", "q2" } });
     }
 
-    @Test(groups = { "unit" })
+    @Test(groups = { "private" })
     public void testExecuteQueries() throws IOException, SQLException {
         final String url = "jdbcx:sqlite::memory:";
         Assert.assertFalse(Main.executeQueries(url, false, 1000, null, null, null, null,

--- a/driver/src/test/java/io/github/jdbcx/MainTest.java
+++ b/driver/src/test/java/io/github/jdbcx/MainTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022-2024, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MainTest {
+    @Test(groups = { "unit" })
+    public void testCloseConnection() throws SQLException {
+        Main.closeQuietly(null);
+        Main.closeQuietly(new ByteArrayInputStream(new byte[1]));
+
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:", null)) {
+            Assert.assertFalse(conn.isClosed());
+            Main.closeQuietly(conn);
+            Assert.assertTrue(conn.isClosed());
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetOrCreateConnection() throws SQLException {
+        Assert.assertNull(Main.getOrCreateConnection(null, null, null, -1, null, false));
+        Assert.assertNull(Main.getOrCreateConnection(null, null, null, 0, null, true));
+
+        Connection conn = Main.getOrCreateConnection("jdbc:sqlite::memory:", null, null, 1000, "select 2", false);
+        Assert.assertNotNull(conn);
+        for (int i = 0; i < 3; i++) {
+            Assert.assertFalse(conn.isClosed());
+            final Properties props;
+            if (i % 3 == 1) {
+                props = System.getProperties();
+            } else {
+                props = new Properties();
+            }
+            Assert.assertEquals(conn,
+                    Main.getOrCreateConnection("jdbc:sqlite::memory:", props, conn, 1000, "select 2", false));
+        }
+
+        for (int i = 0; i < 100; i++) {
+            Assert.assertFalse(conn.isClosed());
+            conn.close();
+            Assert.assertTrue(conn.isClosed());
+            Connection newConn = Main.getOrCreateConnection("jdbc:sqlite::memory:", null, conn, 1000, "select 3",
+                    false);
+            Assert.assertNotEquals(conn, newConn);
+            Assert.assertTrue(conn.isClosed());
+            Assert.assertFalse(newConn.isClosed());
+            conn = newConn;
+        }
+    }
+
+    static String[][] toArray(List<List<String[]>> list) {
+        List<String[]> result = new LinkedList<>();
+        for (List<String[]> l : list) {
+            result.addAll(l);
+        }
+        return result.toArray(new String[0][2]);
+    }
+
+    @Test(groups = { "unit" })
+    public void testSplitTasks() {
+        Assert.assertEquals(toArray(Main.splitTasks(Collections.emptyList(), 1)), new String[0][]);
+        Assert.assertEquals(toArray(Main.splitTasks(Collections.emptyList(), 2)), new String[0][]);
+
+        Assert.assertEquals(toArray(Main.splitTasks(Collections.singletonList(new String[] { "n", "q" }), 1)),
+                new String[][] { { "n", "q" } });
+        Assert.assertEquals(toArray(Main.splitTasks(Collections.singletonList(new String[] { "n", "q" }), 2)),
+                new String[][] { { "n", "q" } });
+
+        Assert.assertEquals(
+                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }), 1)),
+                new String[][] { { "n1", "q1" }, { "n2", "q2" } });
+        Assert.assertEquals(
+                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }), 2)),
+                new String[][] { { "n1", "q1" }, { "n2", "q2" } });
+
+        Assert.assertEquals(
+                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
+                        new String[] { "n3", "q3" }), 1)),
+                new String[][] { { "n1", "q1" }, { "n2", "q2" }, { "n3", "q3" } });
+        Assert.assertEquals(
+                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
+                        new String[] { "n3", "q3" }), 2)),
+                new String[][] { { "n1", "q1" }, { "n3", "q3" }, { "n2", "q2" } });
+    }
+
+    @Test(groups = { "unit" })
+    public void testExecuteQueries() throws IOException, SQLException {
+        Assert.assertFalse(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null, null, null, null, false));
+        Assert.assertFalse(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null, Collections.emptyList(), null,
+                null, false));
+
+        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Collections.singletonList(new String[] { "first", "select 1" }), null, null, false));
+        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Collections.singletonList(
+                        new String[] { "first", "SELECT name FROM sqlite_master WHERE type='invalid_table'" }),
+                null, null, false));
+        Assert.assertThrows(SQLException.class, () -> Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Collections.singletonList(new String[] { "first", "select '" }), null, null, false));
+
+        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Arrays.asList(new String[] { "first", "select 1" }, new String[] { "2nd", "select 2" }), null, null,
+                false));
+        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Arrays.asList(new String[] { "first", "SELECT name FROM sqlite_master WHERE type='invalid_table'" },
+                        new String[] { "2nd", "select 2" }),
+                null, null, false));
+        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+                Arrays.asList(new String[] { "ddl", "create table if not exists test_execute_queries(a VARCHAR(30))" },
+                        new String[] { "1st", "SELECT name FROM sqlite_master WHERE type='test_execute_queries'" },
+                        new String[] { "2nd", "insert into test_execute_queries values('x')" },
+                        new String[] { "3rd", "select a from test_execute_queries" }),
+                null, null, true));
+    }
+
+    @Test(groups = { "private" })
+    public void testExecuteQueriesInParallel() throws Exception {
+        System.setProperty("verbose", "true");
+        // Main.main(new String[] { "jdbcx:sqlite::memory:",
+        // "@target/test-classes/test-queries/sequential" });
+
+        System.setProperty("tasks", "2");
+        Main.main(new String[] { "jdbcx:sqlite::memory:", "@target/test-classes/test-queries/parallel" });
+    }
+}

--- a/driver/src/test/java/io/github/jdbcx/MainTest.java
+++ b/driver/src/test/java/io/github/jdbcx/MainTest.java
@@ -30,12 +30,20 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class MainTest {
+    static String[][] toArray(List<List<String[]>> list) {
+        List<String[]> result = new LinkedList<>();
+        for (List<String[]> l : list) {
+            result.addAll(l);
+        }
+        return result.toArray(new String[0][2]);
+    }
+
     @Test(groups = { "unit" })
     public void testCloseConnection() throws SQLException {
         Main.closeQuietly(null);
         Main.closeQuietly(new ByteArrayInputStream(new byte[1]));
 
-        try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:", null)) {
+        try (Connection conn = DriverManager.getConnection("jdbcx:sqlite::memory:", null)) {
             Assert.assertFalse(conn.isClosed());
             Main.closeQuietly(conn);
             Assert.assertTrue(conn.isClosed());
@@ -47,7 +55,8 @@ public class MainTest {
         Assert.assertNull(Main.getOrCreateConnection(null, null, null, -1, null, false));
         Assert.assertNull(Main.getOrCreateConnection(null, null, null, 0, null, true));
 
-        Connection conn = Main.getOrCreateConnection("jdbc:sqlite::memory:", null, null, 1000, "select 2", false);
+        Connection conn = Main.getOrCreateConnection("jdbcx:sqlite::memory:", null, null, 1000, "select 2",
+                false);
         Assert.assertNotNull(conn);
         for (int i = 0; i < 3; i++) {
             Assert.assertFalse(conn.isClosed());
@@ -58,28 +67,22 @@ public class MainTest {
                 props = new Properties();
             }
             Assert.assertEquals(conn,
-                    Main.getOrCreateConnection("jdbc:sqlite::memory:", props, conn, 1000, "select 2", false));
+                    Main.getOrCreateConnection("jdbcx:sqlite::memory:", props, conn, 1000,
+                            "select 2", false));
         }
 
         for (int i = 0; i < 100; i++) {
             Assert.assertFalse(conn.isClosed());
             conn.close();
             Assert.assertTrue(conn.isClosed());
-            Connection newConn = Main.getOrCreateConnection("jdbc:sqlite::memory:", null, conn, 1000, "select 3",
+            Connection newConn = Main.getOrCreateConnection("jdbcx:sqlite::memory:", null, conn, 1000,
+                    "select 3",
                     false);
             Assert.assertNotEquals(conn, newConn);
             Assert.assertTrue(conn.isClosed());
             Assert.assertFalse(newConn.isClosed());
             conn = newConn;
         }
-    }
-
-    static String[][] toArray(List<List<String[]>> list) {
-        List<String[]> result = new LinkedList<>();
-        for (List<String[]> l : list) {
-            result.addAll(l);
-        }
-        return result.toArray(new String[0][2]);
     }
 
     @Test(groups = { "unit" })
@@ -93,47 +96,65 @@ public class MainTest {
                 new String[][] { { "n", "q" } });
 
         Assert.assertEquals(
-                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }), 1)),
+                toArray(Main.splitTasks(
+                        Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }),
+                        1)),
                 new String[][] { { "n1", "q1" }, { "n2", "q2" } });
         Assert.assertEquals(
-                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }), 2)),
+                toArray(Main.splitTasks(
+                        Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" }),
+                        2)),
                 new String[][] { { "n1", "q1" }, { "n2", "q2" } });
 
         Assert.assertEquals(
-                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
-                        new String[] { "n3", "q3" }), 1)),
+                toArray(Main.splitTasks(
+                        Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
+                                new String[] { "n3", "q3" }),
+                        1)),
                 new String[][] { { "n1", "q1" }, { "n2", "q2" }, { "n3", "q3" } });
         Assert.assertEquals(
-                toArray(Main.splitTasks(Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
-                        new String[] { "n3", "q3" }), 2)),
+                toArray(Main.splitTasks(
+                        Arrays.asList(new String[] { "n1", "q1" }, new String[] { "n2", "q2" },
+                                new String[] { "n3", "q3" }),
+                        2)),
                 new String[][] { { "n1", "q1" }, { "n3", "q3" }, { "n2", "q2" } });
     }
 
     @Test(groups = { "unit" })
     public void testExecuteQueries() throws IOException, SQLException {
-        Assert.assertFalse(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null, null, null, null, false));
-        Assert.assertFalse(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null, Collections.emptyList(), null,
+        final String url = "jdbcx:sqlite::memory:";
+        Assert.assertFalse(Main.executeQueries(url, false, 1000, null, null, null, null,
+                false));
+        Assert.assertFalse(Main.executeQueries(url, false, 1000, null,
+                Collections.emptyList(), null,
                 null, false));
 
-        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+        Assert.assertTrue(Main.executeQueries(url, false, 1000, null,
                 Collections.singletonList(new String[] { "first", "select 1" }), null, null, false));
-        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
+        Assert.assertTrue(Main.executeQueries(url, false, 1000, null,
                 Collections.singletonList(
-                        new String[] { "first", "SELECT name FROM sqlite_master WHERE type='invalid_table'" }),
+                        new String[] { "first",
+                                "SELECT name FROM sqlite_master WHERE type='invalid_table'" }),
                 null, null, false));
-        Assert.assertThrows(SQLException.class, () -> Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
-                Collections.singletonList(new String[] { "first", "select '" }), null, null, false));
+        Assert.assertThrows(SQLException.class,
+                () -> Main.executeQueries(url, false, 1000, null,
+                        Collections.singletonList(new String[] { "first", "select '" }), null,
+                        null, false));
 
-        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
-                Arrays.asList(new String[] { "first", "select 1" }, new String[] { "2nd", "select 2" }), null, null,
+        Assert.assertTrue(Main.executeQueries(url, false, 1000, null,
+                Arrays.asList(new String[] { "first", "select 1" }, new String[] { "2nd", "select 2" }),
+                null, null,
                 false));
-        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
-                Arrays.asList(new String[] { "first", "SELECT name FROM sqlite_master WHERE type='invalid_table'" },
+        Assert.assertTrue(Main.executeQueries(url, false, 1000, null,
+                Arrays.asList(new String[] { "first",
+                        "SELECT name FROM sqlite_master WHERE type='invalid_table'" },
                         new String[] { "2nd", "select 2" }),
                 null, null, false));
-        Assert.assertTrue(Main.executeQueries("jdbc:sqlite::memory:", false, 1000, null,
-                Arrays.asList(new String[] { "ddl", "create table if not exists test_execute_queries(a VARCHAR(30))" },
-                        new String[] { "1st", "SELECT name FROM sqlite_master WHERE type='test_execute_queries'" },
+        Assert.assertTrue(Main.executeQueries(url, false, 1000, null,
+                Arrays.asList(new String[] { "ddl",
+                        "create table if not exists test_execute_queries(a VARCHAR(30))" },
+                        new String[] { "1st",
+                                "SELECT name FROM sqlite_master WHERE type='test_execute_queries'" },
                         new String[] { "2nd", "insert into test_execute_queries values('x')" },
                         new String[] { "3rd", "select a from test_execute_queries" }),
                 null, null, true));

--- a/driver/src/test/java/io/github/jdbcx/QueryModeTest.java
+++ b/driver/src/test/java/io/github/jdbcx/QueryModeTest.java
@@ -34,6 +34,10 @@ public class QueryModeTest {
     @Test(groups = { "unit" })
     public void testFromPath() {
         Assert.assertNull(QueryMode.fromPath("?", null));
+        Assert.assertNull(QueryMode.fromPath("mycsv", null));
+        Assert.assertNull(QueryMode.fromPath("my.csv", null));
+
+        Assert.assertEquals(QueryMode.fromPath("async", null), QueryMode.ASYNC);
         Assert.assertEquals(QueryMode.fromPath("async", QueryMode.DIRECT), QueryMode.ASYNC);
 
         Assert.assertEquals(QueryMode.fromPath("?"), QueryMode.SUBMIT);

--- a/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
@@ -90,5 +90,9 @@ public class ClickHouseMapperTest extends ResultMapperTest {
 
         Assert.assertEquals(mapper.toRemoteTable("", Format.AVRO, Compression.NONE, result),
                 "url('',Avro,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='avro/binary'))");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.ARROW, Compression.NONE, result),
+                "url('',Arrow,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='application/vnd.apache.arrow.file'))");
+        Assert.assertEquals(mapper.toRemoteTable("", Format.ARROW_STREAM, Compression.NONE, result),
+                "url('',ArrowStream,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='application/vnd.apache.arrow.stream'))");
     }
 }

--- a/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
+++ b/driver/src/test/java/io/github/jdbcx/dialect/ClickHouseMapperTest.java
@@ -87,5 +87,8 @@ public class ClickHouseMapperTest extends ResultMapperTest {
                 "url('123',CSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='text/csv'))");
         Assert.assertEquals(mapper.toRemoteTable("", Format.TSV, Compression.GZIP, result),
                 "url('',TSVWithNames,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='text/tab-separated-values','accept-encoding'='gzip'))");
+
+        Assert.assertEquals(mapper.toRemoteTable("", Format.AVRO, Compression.NONE, result),
+                "url('',Avro,'`a\\\\`b` Nullable(Boolean),`c` Decimal(18,3)',headers('accept'='avro/binary'))");
     }
 }

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
@@ -242,6 +242,34 @@ public class QueryParserTest {
     }
 
     @Test(groups = { "unit" })
+    public void testSplit() {
+        Assert.assertEquals(QueryParser.split(null), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(""), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(";; "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(";; \n;; "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(";; \n;; \n;; "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(";; \n;; \n;; \n;; "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(" \r\n\t  "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(" \r\n;; \t  "), Collections.emptyList());
+        Assert.assertEquals(QueryParser.split(";; \n;; ...\r\n \r\n;; \t  "), Collections.emptyList());
+
+        String[][] expected = new String[][] { { "Query #1", "select 1" } };
+        Assert.assertEquals(QueryParser.split("select 1").toArray(expected), expected);
+        Assert.assertEquals(QueryParser.split(";; the first query\nselect 1").toArray(expected),
+                expected = new String[][] { { "the first query", "select 1" } });
+        Assert.assertEquals(
+                QueryParser.split(
+                        "\n;; q1\n;; q2\n\n;; q3 \n\n\n;; the first query\n;; my query\n;; \nselect 1\n;; test query")
+                        .toArray(expected),
+                expected = new String[][] { { "Query #1", "select 1" } });
+        Assert.assertEquals(QueryParser.split(" select 1 \n;; \t  \r\n\tselect 2\r\n\n").toArray(expected),
+                expected = new String[][] { { "Query #1", "select 1" }, { "Query #2", "select 2" } });
+        Assert.assertEquals(
+                QueryParser.split(";; q1\n select 1 \n;; q3 \n;;  q2\t  \r\n\tselect 2\r\n;; ").toArray(expected),
+                expected = new String[][] { { "q1", "select 1" }, { "q2", "select 2" } });
+    }
+
+    @Test(groups = { "unit" })
     public void testParse() {
         Properties props = new Properties();
         String str;
@@ -484,5 +512,12 @@ public class QueryParserTest {
                 Arrays.asList("", ""), Collections.singletonList(new ExecutableBlock(1, "script", props, "", false))));
         Assert.assertEquals(QueryParser.parse("[%script%]", VariableTag.SQUARE_BRACKET, props), new ParsedQuery(
                 Arrays.asList("", ""), Collections.singletonList(new ExecutableBlock(1, "script", props, "", false))));
+    }
+
+    @Test(groups = { "unit" })
+    public void testStatements() {
+        ParsedQuery query = QueryParser.parse("select 1\n  -- {%context: a=1,b=2%}\n ; select 2", VariableTag.BRACE,
+                null);
+        Assert.assertNotNull(query);
     }
 }

--- a/driver/src/test/resources/test-queries/parallel/q1.sql
+++ b/driver/src/test/resources/test-queries/parallel/q1.sql
@@ -1,0 +1,5 @@
+;; create table test_queries_g1t1
+create table if not exists test_queries_g1t1 (i INTEGER, s VARCHAR(30))
+
+;; create table test_queries_g1t2
+create table if not exists test_queries_g1t2 (name VARCHAR(30), desc VARCHAR(100))

--- a/driver/src/test/resources/test-queries/parallel/q2.sql
+++ b/driver/src/test/resources/test-queries/parallel/q2.sql
@@ -1,0 +1,14 @@
+;; select 1
+select 1
+
+;; insert test_queries_g1t2
+insert into test_queries_g1t2 values('one', 'desc')
+
+;; select 2
+select 2
+
+;; select test_queries_g1t2
+select * from test_queries_g1t2
+
+;; truncate test_queries_g1t1
+delete from test_queries_g1t1

--- a/driver/src/test/resources/test-queries/sequential/1_ddl.sql
+++ b/driver/src/test/resources/test-queries/sequential/1_ddl.sql
@@ -1,0 +1,5 @@
+;; create table test_queries_g1t1
+create table if not exists test_queries_g1t1 (i INTEGER, s VARCHAR(30))
+
+;; create table test_queries_g1t2
+create table if not exists test_queries_g1t2 (name VARCHAR(30), desc VARCHAR(100))

--- a/driver/src/test/resources/test-queries/sequential/2_dml.sql
+++ b/driver/src/test/resources/test-queries/sequential/2_dml.sql
@@ -1,0 +1,11 @@
+;; select test_queries_g1t2
+select * from test_queries_g1t2
+
+;; insert into test_queries_g1t1
+insert into test_queries_g1t1 values(1, 'one')
+
+;; select test_queries_g1t1
+select * from test_queries_g1t1
+
+;; truncate test_queries_g1t1
+delete from test_queries_g1t1

--- a/pom.xml
+++ b/pom.xml
@@ -1113,6 +1113,7 @@
                 </property>
             </activation>
             <properties>
+                <arrow.version>15.0.2</arrow.version>
                 <caffeine.version>2.9.2</caffeine.version>
                 <hikaricp.version>4.0.3</hikaricp.version>
                 <testng.version>7.5.1</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -867,18 +867,18 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>java17</id>
+                        <id>java21</id>
                         <phase>none</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <release>17</release>
+                            <release>21</release>
                             <jdkToolchain>
-                                <version>17</version>
+                                <version>21</version>
                             </jdkToolchain>
                             <compileSourceRoots>
-                                <compileSourceRoot>${project.basedir}/src/main/java17</compileSourceRoot>
+                                <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
                             </compileSourceRoots>
                             <multiReleaseOutput>true</multiReleaseOutput>
                         </configuration>
@@ -1134,9 +1134,9 @@
             </build>
         </profile>
         <profile>
-            <id>compile-java17</id>
+            <id>compile-java21</id>
             <activation>
-                <jdk>[17,)</jdk>
+                <jdk>[21,)</jdk>
                 <property>
                     <name>!j8</name>
                 </property>
@@ -1147,7 +1147,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>java17</id>
+                                <id>java21</id>
                                 <phase>compile</phase>
                             </execution>
                         </executions>
@@ -1177,7 +1177,7 @@
                                     <version>11</version>
                                 </jdk>
                                 <jdk>
-                                    <version>17</version>
+                                    <version>21</version>
                                 </jdk>
                             </toolchains>
                         </configuration>
@@ -1190,7 +1190,7 @@
                                 <phase>compile</phase>
                             </execution>
                             <execution>
-                                <id>java17</id>
+                                <id>java21</id>
                                 <phase>compile</phase>
                             </execution>
                         </executions>
@@ -1382,7 +1382,7 @@
                                     <version>11</version>
                                 </jdk>
                                 <jdk>
-                                    <version>17</version>
+                                    <version>21</version>
                                 </jdk>
                             </toolchains>
                         </configuration>
@@ -1395,7 +1395,7 @@
                                 <phase>compile</phase>
                             </execution>
                             <execution>
-                                <id>java17</id>
+                                <id>java21</id>
                                 <phase>compile</phase>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
         <ccc.src.dir>${project.build.directory}/generated-sources/ccc</ccc.src.dir>
 
-        <arrow.version>16.0.0</arrow.version>
+        <arrow.version>16.1.0</arrow.version>
         <avro.version>1.11.3</avro.version>
         <brotli.version>0.1.2</brotli.version>
         <brotli4j.version>1.16.0</brotli4j.version>
@@ -98,28 +98,28 @@
         <duckdb.version>0.10.2</duckdb.version>
         <graphql.version>22.0</graphql.version>
         <groovy.version>4.0.21</groovy.version>
-        <gson.version>2.10.1</gson.version>
+        <gson.version>2.11.0</gson.version>
         <hadoop.version>3.4.0</hadoop.version>
         <hikaricp.version>5.1.0</hikaricp.version>
-        <jackson.version>2.17.0</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <janino.version>3.1.12</janino.version>
         <jctools.version>4.0.3</jctools.version>
         <jmespath.version>0.6.0</jmespath.version>
         <lz4.version>1.8.0</lz4.version>
-        <mariadb.version>3.3.3</mariadb.version>
-        <micrometer.version>1.12.5</micrometer.version>
+        <mariadb.version>3.4.0</mariadb.version>
+        <micrometer.version>1.13.0</micrometer.version>
         <msgpack.version>0.9.8</msgpack.version>
         <mysql.version>8.4.0</mysql.version>
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.14.0</parquet.version>
         <postgresql.version>42.7.3</postgresql.version>
         <sqlite.version>3.45.3.0</sqlite.version>
-        <rhino.version>1.7.14</rhino.version>
+        <rhino.version>1.7.15</rhino.version>
         <roaring-bitmap.version>1.0.6</roaring-bitmap.version>
         <slf4j.version>2.0.13</slf4j.version>
         <snappy.version>1.1.10.5</snappy.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
         <testng.version>7.10.2</testng.version>
 
         <shade.base>${project.groupId}.internal</shade.base>
@@ -238,6 +238,12 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -496,6 +502,10 @@
                     <exclusion>
                         <groupId>com.github.luben</groupId>
                         <artifactId>zstd-jni</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.avro</groupId>

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -66,8 +66,8 @@ import io.github.jdbcx.driver.ConnectionManager;
 import io.github.jdbcx.executor.WebExecutor;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 public abstract class BridgeServer implements RemovalListener<String, QueryInfo> {
     private static final Logger log = LoggerFactory.getLogger(BridgeServer.class);
@@ -310,10 +310,7 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
     }
 
     protected final void writeMetrics(OutputStream out) throws IOException {
-        try (Writer writer = new BufferedWriter(new OutputStreamWriter(out, Constants.DEFAULT_CHARSET),
-                Constants.DEFAULT_BUFFER_SIZE)) {
-            promRegistry.scrape(writer);
-        }
+        promRegistry.scrape(out);
     }
 
     protected void query(Request request, Properties config) throws IOException {

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -566,7 +566,7 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
                         } else if (state == 0) { // no result
                             query(request, config);
                         } else { // active result
-                            respond(request, HttpURLConnection.HTTP_ACCEPTED);
+                            respond(request, HttpURLConnection.HTTP_NO_CONTENT);
                         }
                     }
                     break;

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -452,6 +452,8 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
                 defaultMode = m;
                 if (index > 0) {
                     path = path.substring(index + 1);
+                } else {
+                    path = Constants.EMPTY_STRING;
                 }
             } else {
                 defaultMode = null;

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -103,10 +103,9 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
 
     public static final Option OPTION_BACKLOG = Option.of("server.backlog", "Server backlog", "0");
     public static final Option OPTION_ACL = Option.of("server.acl",
-            "Server access control list, defaults to acl.properties in current directory", "acl.properties");
-    public static final Option OPTION_SECRET = Option
-            .of(new String[] { "server.secret",
-                    "Server secret for ACL encryption, only used when authentication & authorization are enabled" });
+            "Server access control list, defaults to acl.properties in current directory.", "acl.properties");
+    public static final Option OPTION_THREADS = Option.of("server.threads", "Maximum size of the thread pool.",
+            String.valueOf(Constants.MIN_CORE_THREADS));
 
     protected static final Properties extractConfig(Map<String, String> params) {
         Properties config = new Properties();
@@ -162,7 +161,7 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
     protected final String baseUrl;
     protected final String context;
     protected final int backlog;
-    // protected final int threads;
+    protected final int threads;
 
     protected final String tag;
 
@@ -254,6 +253,7 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
         CaffeineCacheMetrics.monitor(promRegistry, queries, "query");
 
         backlog = Integer.parseInt(OPTION_BACKLOG.getJdbcxValue(props));
+        threads = Integer.parseInt(OPTION_THREADS.getJdbcxValue(props));
 
         tag = Option.TAG.getJdbcxValue(props);
 

--- a/server/src/main/java/io/github/jdbcx/server/Request.java
+++ b/server/src/main/java/io/github/jdbcx/server/Request.java
@@ -68,6 +68,14 @@ public class Request {
         return info.getResult() != null;
     }
 
+    public int getResultState() {
+        final Result<?> result = info.getResult();
+        if (result != null) {
+            return result.isActive() ? -1 : 1;
+        }
+        return 0;
+    }
+
     public boolean isTransactional() {
         return !info.txid.isEmpty();
     }

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -45,7 +45,7 @@ import io.github.jdbcx.executor.WebExecutor;
 import io.github.jdbcx.server.impl.JdkHttpServer;
 
 public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
-    protected static final String DUCKDB_TEST_QUERY = "SELECT generate_series::INT n, date_add(today(), n) d, d::VARCHAR s FROM generate_series(1, %d)";
+    protected static final String DUCKDB_TEST_QUERY = "SELECT generate_series::INT n, date_add(today(), n) d, d::VARCHAR s FROM generate_series(1, %d) order by 1";
 
     protected JdkHttpServer server;
 

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -534,9 +534,8 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         final String innerQuery = Utils.format(DUCKDB_TEST_QUERY, count);
         try (Connection conn = DriverManager.getConnection("jdbcx:ch://" + getClickHouseServer(), props);
                 Statement stmt = conn.createStatement();
-                ResultSet rs = stmt
-                        .executeQuery(
-                                Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n"))) {
+                ResultSet rs = stmt.executeQuery(
+                        Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n settings http_make_head_request=0"))) {
             for (int i = 1; i <= count; i++) {
                 Assert.assertTrue(rs.next(), "Should have record #" + i + " from query: " + query);
                 Assert.assertEquals(rs.getInt(1), i, query);
@@ -555,9 +554,8 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         final String innerQuery = Utils.format(DUCKDB_TEST_QUERY, count);
         try (Connection conn = DriverManager.getConnection("jdbcx:duckdb:", props);
                 Statement stmt = conn.createStatement();
-                ResultSet rs = stmt
-                        .executeQuery(
-                                Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n"))) {
+                ResultSet rs = stmt.executeQuery(
+                        Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n"))) {
             for (int i = 1; i <= count; i++) {
                 Assert.assertTrue(rs.next(), "Should have record #" + i + " from query: " + query);
                 Assert.assertEquals(rs.getInt(1), i, query);

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -71,11 +71,11 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
                         ".csv.gz): %s }}" },
                 { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
                         ".csv.zstd): %s }}" },
-                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() + ".avro): %s }}" },
-                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
-                        ".avro?codec=deflate): %s }}" },
-                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
-                        ".avro?codec=snappy): %s }}" },
+                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() + ".avro): %s }}" },
+                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
+                //         ".avro?codec=deflate): %s }}" },
+                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
+                //         ".avro?codec=snappy): %s }}" },
                 // https://github.com/ClickHouse/ClickHouse/pull/58805
                 // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
                 // ".avro?codec=zstd): %s }}" },

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -535,7 +535,7 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         try (Connection conn = DriverManager.getConnection("jdbcx:ch://" + getClickHouseServer(), props);
                 Statement stmt = conn.createStatement();
                 ResultSet rs = stmt.executeQuery(
-                        Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n settings http_make_head_request=0"))) {
+                        Utils.format(query, innerQuery) + (query.startsWith("{{") ? "" : " order by n"))) {
             for (int i = 1; i <= count; i++) {
                 Assert.assertTrue(rs.next(), "Should have record #" + i + " from query: " + query);
                 Assert.assertEquals(rs.getInt(1), i, query);

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -71,11 +71,11 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
                         ".csv.gz): %s }}" },
                 { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
                         ".csv.zstd): %s }}" },
-                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() + ".avro): %s }}" },
-                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
-                //         ".avro?codec=deflate): %s }}" },
-                // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
-                //         ".avro?codec=snappy): %s }}" },
+                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() + ".avro): %s }}" },
+                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
+                        ".avro?codec=deflate): %s }}" },
+                { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
+                        ".avro?codec=snappy): %s }}" },
                 // https://github.com/ClickHouse/ClickHouse/pull/58805
                 // { "select * from {{ bridge(path=async/" + UUID.randomUUID().toString() +
                 // ".avro?codec=zstd): %s }}" },

--- a/server/src/test/java/io/github/jdbcx/server/RequestTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/RequestTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import io.github.jdbcx.Compression;
 import io.github.jdbcx.Format;
 import io.github.jdbcx.QueryMode;
+import io.github.jdbcx.Result;
 
 public class RequestTest {
     @Test(groups = { "unit" })
@@ -53,6 +54,24 @@ public class RequestTest {
         Assert.assertEquals(request.getCompression(), Compression.SNAPPY);
         Assert.assertEquals(request.getFormat(), Format.AVRO_JSON);
         Assert.assertNotNull(request.getImplementation(Request.class));
+    }
+
+    @Test(groups = { "unit" })
+    public void testResult() {
+        Request request = new Request(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        Assert.assertFalse(request.hasResult(), "Should not have result");
+        Assert.assertNull(request.getQueryInfo().getResult(), "Should not have result");
+        Assert.assertEquals(request.getResultState(), 0);
+
+        request.getQueryInfo().setResult(Result.of(1L));
+        Assert.assertTrue(request.hasResult(), "Should have result");
+        Assert.assertNotNull(request.getQueryInfo().getResult(), "Should have result");
+        Assert.assertEquals(request.getResultState(), 1);
+
+        request.getQueryInfo().getResult().rows();
+        Assert.assertTrue(request.hasResult(), "Should still have result");
+        Assert.assertNotNull(request.getQueryInfo().getResult(), "Should still have result");
+        Assert.assertEquals(request.getResultState(), -1);
     }
 
     @Test(groups = { "unit" })


### PR DESCRIPTION
* use `^;; [comment]$` to split queries, for instance, the following are two queries: `select 1` and `select 2`
  ```sql
  select 1
  ;; this comment will be overridden by the subsequent one
  ;; the second query
  select 2
  ```
* add `* ` prefix for verbose output so they can be easily excluded using grep
* wildcard can be used to specify multiple files, for examples:
  ```bash
  java -jar jdbcx.jar '<url>' '@?.sql'
  
  # search *.sql if you only specified a directory, same as the last one
  java -jar jdbcx.jar '<url>' '@subDir'

  java -jar jdbcx.jar '<url>' '@subDir/*.sql'
  ```
* new CLI options `tasks` and `taskCheckInterval` for running queries in parallel

Will use separate PRs for 1) reuse serdes for all supported output formats; and 2) multi-queries support in bridge server.