### PR TITLE
support underscore variable

### DIFF
--- a/core/src/test/resources/docker-compose.yml
+++ b/core/src/test/resources/docker-compose.yml
@@ -5,25 +5,26 @@
 
 # https://hub.docker.com/_/mariadb
 mariadb:
-  image: mariadb:11.3
+  image: mariadb:11.5
   environment:
     MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "1"
 
 # https://hub.docker.com/_/mysql
 mysql:
-  image: mysql:8.4
+  image: mysql:9.0
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
 # https://hub.docker.com/_/postgres
 postgresql:
-  image: postgres:16.2
+  image: postgres:16.4
   environment:
     POSTGRES_HOST_AUTH_METHOD: "trust"
 
 # https://hub.docker.com/r/clickhouse/clickhouse-server/
 clickhouse:
-  # 24.3 has problem working behind the proxy
+  # 24.3+ has problem dealing with absolute-form in request
+  # See https://github.com/ClickHouse/ClickHouse/issues/58828
   image: clickhouse/clickhouse-server:23.8
   links:
     - mysql
@@ -31,7 +32,7 @@ clickhouse:
 
 # https://hub.docker.com/r/voltrondata/flight-sql
 flightsql:
-  image: voltrondata/flight-sql:v1.3.4
+  image: voltrondata/flight-sql:v1.4.1
   environment:
     TLS_ENABLED: "0"
     FLIGHT_PASSWORD: "f"

--- a/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/ExecutableBlock.java
@@ -15,11 +15,16 @@
  */
 package io.github.jdbcx.driver;
 
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
 
 import io.github.jdbcx.Checker;
 import io.github.jdbcx.Option;
+import io.github.jdbcx.Utils;
+import io.github.jdbcx.VariableTag;
+
+import static io.github.jdbcx.QueryContext.KEY_BRIDGE;
 
 /**
  * An executable block represents either a function, which returns a value, or a
@@ -32,9 +37,60 @@ import io.github.jdbcx.Option;
  * </ul>
  */
 public final class ExecutableBlock {
+    static final String BUILTIN_VAR = "_";
+    static final String BUILTIN_VAR_PREFIX = BUILTIN_VAR.concat(".");
+
     // reserved keyword
     static final String KEYWORD_TABLE = "table";
     static final String KEYWORD_VALUES = "values";
+
+    static boolean hasBuiltInVariable(String template, VariableTag tag) {
+        final char leftChar = tag.leftChar();
+        final char rightChar = tag.rightChar();
+        final char varChar = tag.variableChar();
+        final char escapeChar = tag.escapeChar();
+
+        boolean escaped = false;
+        int startIndex = -1;
+        int colonIndex = -1;
+        for (int i = 0, len = template.length(); i < len; i++) {
+            char ch = template.charAt(i);
+            if (escaped) {
+                escaped = false;
+            } else if (ch == escapeChar) {
+                escaped = true;
+            } else if (startIndex == -1) {
+                if (ch == varChar && i + 2 < len && template.charAt(i + 1) == leftChar) {
+                    startIndex = i + 2;
+                    i++;
+                }
+            } else {
+                if (ch == ':') {
+                    colonIndex = i;
+                } else if (ch == rightChar) {
+                    final String key = template.substring(startIndex, colonIndex >= 0 ? colonIndex : i).trim();
+                    final int klen = key.length();
+                    if ((klen > BUILTIN_VAR_PREFIX.length() && key.startsWith(BUILTIN_VAR_PREFIX))
+                            || (klen == 1 && key.charAt(0) == '_')) {
+                        return true;
+                    }
+                    startIndex = -1;
+                    colonIndex = -1;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether an extension name is for bridge server or not.
+     *
+     * @param extension extension name
+     * @return true if it's for bridge server; false otherwise
+     */
+    static boolean isForBridge(String extension) {
+        return KEYWORD_TABLE.equals(extension) || KEYWORD_VALUES.equals(extension);
+    }
 
     private final int index;
     private final String extension;
@@ -42,16 +98,26 @@ public final class ExecutableBlock {
     private final String content;
     private final boolean output;
 
-    ExecutableBlock(int index, String extension, Properties props, String content, boolean output) {
-        if (extension == null || props == null || content == null) {
-            throw new IllegalArgumentException("Non-null extension name, properties, and content are required!");
-        }
-
+    ExecutableBlock(int index, String extension, VariableTag tag, Properties props, String content, boolean output) {
         this.index = index;
         this.extension = extension;
         this.props = props;
-        this.content = content;
+        if (!KEY_BRIDGE.equals(extension) && !isForBridge(extension) && hasBuiltInVariable(content, tag)) {
+            Properties vars = new Properties();
+            vars.setProperty(BUILTIN_VAR, extension);
+            for (Entry<Object, Object> entry : props.entrySet()) {
+                vars.put(BUILTIN_VAR_PREFIX + entry.getKey(), entry.getValue());
+            }
+            this.content = Utils.applyVariablesWithDefault(content, tag, vars);
+        } else {
+            this.content = content;
+        }
         this.output = output;
+    }
+
+    // mainly for testing
+    ExecutableBlock(int index, String extension, Properties props, String content, boolean output) {
+        this(index, extension, VariableTag.BRACE, props, content, output);
     }
 
     public int getIndex() {

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryBuilder.java
@@ -73,7 +73,7 @@ public final class QueryBuilder {
                     props.setProperty(DriverExtension.PROPERTY_PATH, QueryMode.ASYNC.path());
                 }
                 VariableTag tag = VariableTag.valueOf(Option.TAG.getValue(props));
-                this.blocks[i] = new ExecutableBlock(block.getIndex(), QueryContext.KEY_BRIDGE, props,
+                this.blocks[i] = new ExecutableBlock(block.getIndex(), QueryContext.KEY_BRIDGE, tag, props,
                         block.hasOutput() ? tag.function(block.getContent()) : tag.procedure(block.getContent()),
                         block.hasOutput());
             }

--- a/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/QueryParser.java
@@ -232,7 +232,7 @@ public final class QueryParser {
     }
 
     static String[] extractBridgeBlock(String block, String extension, int beginIndex, int len) {
-        if (!ExecutableBlock.KEYWORD_TABLE.equals(extension) && !ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
+        if (!ExecutableBlock.isForBridge(extension)) {
             return Constants.EMPTY_STRING_ARRAY;
         }
 
@@ -329,8 +329,7 @@ public final class QueryParser {
 
                     if (j == len) {
                         extension = block.substring(beginIndex, i);
-                        if (ExecutableBlock.KEYWORD_TABLE.equals(extension)
-                                || ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
+                        if (ExecutableBlock.isForBridge(extension)) {
                             return new String[] { extension, Constants.EMPTY_STRING };
                         }
                         script = Constants.EMPTY_STRING;
@@ -363,8 +362,7 @@ public final class QueryParser {
         if (script == null) {
             if (scope == 0) {
                 extension = block.substring(beginIndex);
-                if (ExecutableBlock.KEYWORD_TABLE.equals(extension)
-                        || ExecutableBlock.KEYWORD_VALUES.equals(extension)) {
+                if (ExecutableBlock.isForBridge(extension)) {
                     return new String[] { extension, Constants.EMPTY_STRING };
                 }
                 script = Constants.EMPTY_STRING;
@@ -382,7 +380,7 @@ public final class QueryParser {
             props.putAll(vars);
         }
         String[] parsed = parseExecutableBlock(Utils.applyVariables(executableBlock, tag, vars), tag, props);
-        return new ExecutableBlock(id, parsed[0], props, parsed[1], false);
+        return new ExecutableBlock(id, parsed[0], tag, props, parsed[1], false);
     }
 
     static void addExecutableBlock(StringBuilder builder, String executableBlock, VariableTag tag, Properties vars,
@@ -402,7 +400,7 @@ public final class QueryParser {
             blocks.add(parseDependentExecutableBlock(parts.size(), preQuery, tag, vars));
             parts.add(Constants.EMPTY_STRING); // placeholder of pre-query
         }
-        blocks.add(new ExecutableBlock(parts.size(), parsed[0], props, parsed[1], output));
+        blocks.add(new ExecutableBlock(parts.size(), parsed[0], tag, props, parsed[1], output));
         parts.add(Constants.EMPTY_STRING); // placeholder of current query
         if (!Checker.isNullOrEmpty(postQuery)) {
             blocks.add(parseDependentExecutableBlock(parts.size(), postQuery, tag, vars));

--- a/driver/src/test/java/io/github/jdbcx/driver/ExecutableBlockTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/ExecutableBlockTest.java
@@ -21,25 +21,60 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.github.jdbcx.Option;
+import io.github.jdbcx.VariableTag;
 
 public class ExecutableBlockTest {
     @Test(groups = { "unit" })
-    public void testConstructor() {
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, null, null, null, false));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, "", null, null, false));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, "", new Properties(), null, false));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, null, new Properties(), null, false));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, null, new Properties(), "", false));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> new ExecutableBlock(0, null, null, "", false));
+    public void testHasBuiltInVariable() {
+        Assert.assertThrows(NullPointerException.class, () -> ExecutableBlock.hasBuiltInVariable("", null));
+        Assert.assertThrows(NullPointerException.class,
+                () -> ExecutableBlock.hasBuiltInVariable(null, VariableTag.ANGLE_BRACKET));
 
-        ExecutableBlock block = new ExecutableBlock(-1, "ex", new Properties(), "...", true);
-        Assert.assertEquals(block, new ExecutableBlock(-1, "ex", new Properties(), "...", true));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("_", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("$\\{_}", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("${__}", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("${_.}", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("${_.:}", VariableTag.BRACE));
+        Assert.assertFalse(ExecutableBlock.hasBuiltInVariable("${.:_}", VariableTag.BRACE));
+
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_:}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_:x}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("this is ${ _ }!", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_.a}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_.a:}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("${_.a:b}", VariableTag.BRACE));
+        Assert.assertTrue(ExecutableBlock.hasBuiltInVariable("this is ${ _.a }!", VariableTag.BRACE));
+    }
+
+    @Test(groups = { "unit" })
+    public void testIsForBridge() {
+        Assert.assertFalse(ExecutableBlock.isForBridge(null));
+        Assert.assertFalse(ExecutableBlock.isForBridge(""));
+        Assert.assertFalse(ExecutableBlock.isForBridge("db"));
+
+        Assert.assertTrue(ExecutableBlock.isForBridge(ExecutableBlock.KEYWORD_TABLE));
+        Assert.assertTrue(ExecutableBlock.isForBridge(ExecutableBlock.KEYWORD_VALUES));
+    }
+
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, null, null, null, null, false));
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, "", null, null, null, false));
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, "", null, new Properties(), null, false));
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, null, null, new Properties(), null, false));
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, null, null, new Properties(), "", false));
+        Assert.assertThrows(NullPointerException.class,
+                () -> new ExecutableBlock(0, null, null, null, "", false));
+
+        ExecutableBlock block = new ExecutableBlock(-1, "ex", VariableTag.BRACE, new Properties(), "...", true);
+        Assert.assertEquals(block, new ExecutableBlock(-1, "ex", VariableTag.BRACE, new Properties(), "...", true));
         Assert.assertEquals(block.getIndex(), -1);
         Assert.assertEquals(block.getExtensionName(), "ex");
         Assert.assertEquals(block.getProperties(), new Properties());
@@ -49,38 +84,56 @@ public class ExecutableBlockTest {
         block.getProperties().setProperty("a", "c");
         Properties props = new Properties();
         props.setProperty("a", "c");
-        Assert.assertEquals(block, new ExecutableBlock(-1, "ex", props, "...", true));
+        Assert.assertEquals(block, new ExecutableBlock(-1, "ex", VariableTag.BRACE, props, "...", true));
+    }
+
+    @Test(groups = { "unit" })
+    public void testConstructorWithBuiltInVariables() {
+        Properties props = new Properties();
+        ExecutableBlock block = new ExecutableBlock(1, "x", VariableTag.BRACE, props, "${_}", false);
+        Assert.assertEquals(block, new ExecutableBlock(1, "x", VariableTag.BRACE, props, "x", false));
+
+        props.setProperty("id", "duckdb1");
+        block = new ExecutableBlock(2, "db", VariableTag.ANGLE_BRACKET, props, "$<_>.$<_.id> ($<_.name:unknown>)",
+                true);
+        Assert.assertEquals(block,
+                new ExecutableBlock(2, "db", VariableTag.ANGLE_BRACKET, props, "db.duckdb1 (unknown)", true));
+
+        block = new ExecutableBlock(3, "bridge", VariableTag.SQUARE_BRACKET, props, "select '$[_.id]'", true);
+        Assert.assertEquals(block.getContent(), "select '$[_.id]'");
+        block = new ExecutableBlock(4, "Bridge", VariableTag.SQUARE_BRACKET, props, "select '$[_.id]'", true);
+        Assert.assertEquals(block.getContent(), "select 'duckdb1'");
     }
 
     @Test(groups = { "unit" })
     public void testSameAs() {
         Properties props = new Properties();
-        ExecutableBlock block = new ExecutableBlock(1, "b1", props, "...", true);
-        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b2", props, "...", true)),
+        ExecutableBlock block = new ExecutableBlock(1, "b1", VariableTag.BRACE, props, "...", true);
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b2", VariableTag.BRACE, props, "...", true)),
                 "Should be false since extension is different");
-        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", props, ". .", true)),
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", VariableTag.BRACE, props, ". .", true)),
                 "Should be false since content is different");
-        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", props, "...", false)),
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(1, "b1", VariableTag.BRACE, props, "...", false)),
                 "Should be false since output is different");
 
-        Assert.assertTrue(block.sameAs(new ExecutableBlock(2, "b1", props, "...", true)),
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(2, "b1", VariableTag.BRACE, props, "...", true)),
                 "Should be true because index does not matter");
-        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", new Properties(), "...", true)),
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", VariableTag.BRACE, new Properties(), "...", true)),
                 "Should be true because properties do not matter");
         props.setProperty("a", "b");
-        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", new Properties(), "...", true)),
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(1, "b1", VariableTag.BRACE, new Properties(), "...", true)),
                 "Should be true because properties do not matter");
 
         Properties newProps = new Properties();
         Option.ID.setValue(props, "bb");
-        block = new ExecutableBlock(1, "b1", props, "...", true);
-        Assert.assertFalse(block.sameAs(new ExecutableBlock(2, "b1", newProps, "...", true)),
+        block = new ExecutableBlock(1, "b1", VariableTag.BRACE, props, "...", true);
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(2, "b1", VariableTag.BRACE, newProps, "...", true)),
                 "Should be true because index does not matter");
         Option.ID.setValue(newProps, "bb");
-        Assert.assertTrue(block.sameAs(new ExecutableBlock(2, "b1", newProps, "...", true)),
+        Assert.assertTrue(block.sameAs(new ExecutableBlock(2, "b1", VariableTag.BRACE, newProps, "...", true)),
                 "Should be true because index does not matter");
         Option.ID.setValue(newProps, "aa");
-        Assert.assertFalse(block.sameAs(new ExecutableBlock(2, "b1", newProps, "...", true)),
+        Assert.assertFalse(block.sameAs(new ExecutableBlock(2, "b1", VariableTag.BRACE, newProps, "...", true)),
                 "Should be true because index does not matter");
     }
 }

--- a/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/QueryParserTest.java
@@ -42,7 +42,7 @@ public class QueryParserTest {
                 () -> QueryParser.extractQuotedPart("`123", 1, 4, null, props, '`'));
 
         String str;
-        Assert.assertEquals(QueryParser.extractQuotedPart(str = "'", 0, 1, null, props, '\''),
+        Assert.assertEquals(QueryParser.extractQuotedPart(str = "'", 0, str.length(), null, props, '\''),
                 QueryParser.newPart(1, ""));
         Assert.assertEquals(QueryParser.extractQuotedPart(str = " '' \\''", 1, str.length(), null, props, '\''),
                 QueryParser.newPart(7, "' '"));
@@ -265,7 +265,8 @@ public class QueryParserTest {
         Assert.assertEquals(QueryParser.split(" select 1 \n--;; \t  \r\n\tselect 2\r\n\n").toArray(expected),
                 expected = new String[][] { { "Query #1", "select 1" }, { "Query #2", "select 2" } });
         Assert.assertEquals(
-                QueryParser.split("--;; q1\n select 1 \n--;; q3 \n--;;  q2\t  \r\n\tselect 2\r\n--;; ").toArray(expected),
+                QueryParser.split("--;; q1\n select 1 \n--;; q3 \n--;;  q2\t  \r\n\tselect 2\r\n--;; ")
+                        .toArray(expected),
                 expected = new String[][] { { "q1", "select 1" }, { "q2", "select 2" } });
     }
 

--- a/driver/src/test/java/io/github/jdbcx/extension/DbDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/DbDriverExtensionTest.java
@@ -42,10 +42,10 @@ public class DbDriverExtensionTest extends BaseIntegrationTest {
             }
 
             try (ResultSet rs = stmt
-                    .executeQuery("select '{{ sql(url='jdbc:ch://${ch.server.address}'): select 2}}'")) {
+                    .executeQuery("select '{{ db(url='jdbc:ch://${ch.server.address}'): select ''${_}:${_.url}'', 2}}'")) {
                 Assert.assertNotNull(stmt.getWarnings());
                 Assert.assertTrue(rs.next(), "Should have at least one row");
-                Assert.assertEquals(rs.getString(1), "select 2");
+                Assert.assertEquals(rs.getString(1), "select 'db:jdbc:ch://${ch.server.address}', 2");
                 Assert.assertFalse(rs.next(), "Should have only one row");
             }
         }

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -577,9 +577,10 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
 
         try (Connection conn = DriverManager.getConnection("jdbcx:ch://" + getClickHouseServer(), props);
                 Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("select * from {{ table.db.my-duckdb: select 1}}")) {
+                ResultSet rs = stmt.executeQuery("select * from {{ table.db.my-duckdb: select 1, '${_}.${_.id}'}}")) {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
+            Assert.assertEquals(rs.getString(2), "db.my-duckdb");
             Assert.assertFalse(rs.next());
         }
 
@@ -593,9 +594,9 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
 
         try (Connection conn = DriverManager.getConnection("jdbcx:", props);
                 Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("insert into my_table {{ values.db.my-sqlite: select 1 a }}")) {
+                ResultSet rs = stmt.executeQuery("insert into my_table {{ values.db.my-sqlite: select 1 a, '${_.id}.${_}' B }}")) {
             Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "insert into my_table (\"a\") VALUES\n(1)");
+            Assert.assertEquals(rs.getString(1), "insert into my_table (\"a\",\"B\") VALUES\n(1,'my-sqlite.db')");
             Assert.assertFalse(rs.next());
         }
     }


### PR DESCRIPTION
```sql
-- same as: {{ db.my-db1: select 'db.my-db1' }}
{{ db.my-db1: select '${_}.${_.id}' }}

-- same as: select * from {{ table.db.my-db1: select 'db.my-db1' }}
select * from {{ table.db.my-db1: select '${_}.${_.id}' }}
```