### PR TITLE
support overrideable parameters

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -123,7 +123,8 @@ public final class Option implements Serializable {
             "Execution timeout in milliseconds. A negative value or 0 disables the timeout.", "0");
 
     public static final Option WORK_DIRECTORY = Option.of("work.dir",
-            "Path to the working directory. If left empty, the current directory will be used.", "");
+            "Path to the working directory. If left empty, the current directory will be used.",
+            Constants.EMPTY_STRING);
 
     public static final Option INPUT_FILE = Option
             .of(new String[] { "input.file",
@@ -135,6 +136,13 @@ public final class Option implements Serializable {
             "Character encoding to use when reading the input stream.", Constants.DEFAULT_CHARSET.name());
     public static final Option OUTPUT_CHARSET = Option.of("output.charset",
             "Character encoding to use when writing the output stream.", Constants.DEFAULT_CHARSET.name());
+
+    /**
+     * Comma separated overrideable parameters.
+     */
+    public static final Option OVERRIDEABLE_PARAMS = Option.of(new String[] { "overrideable.params",
+            "Comma separate list of parameters can be override in query for execution.", Constants.EMPTY_STRING });
+
     /**
      * Proxy to use.
      */

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -1092,6 +1092,10 @@ public final class Utils {
     }
 
     public static List<String> split(String str, char delimiter) {
+        return split(str, delimiter, false, false, false);
+    }
+
+    public static List<String> split(String str, char delimiter, boolean trim, boolean ignoreEmpty, boolean dedup) {
         if (str == null) {
             return Collections.emptyList();
         }
@@ -1101,8 +1105,15 @@ public final class Utils {
         for (int i = 0, len = str.length(); i < len; i++) {
             char ch = str.charAt(i);
             if (ch == delimiter) {
-                list.add(builder.toString());
+                String v = builder.toString();
+                if (trim) {
+                    v = v.trim();
+                }
                 builder.setLength(0);
+                if ((ignoreEmpty && v.isEmpty()) || (dedup && list.contains(v))) {
+                    continue;
+                }
+                list.add(v);
             } else {
                 builder.append(ch);
             }
@@ -1111,7 +1122,13 @@ public final class Utils {
         if (list.isEmpty()) {
             return Collections.singletonList(str);
         } else if (builder.length() > 0) {
-            list.add(builder.toString());
+            String v = builder.toString();
+            if (trim) {
+                v = v.trim();
+            }
+            if (!(ignoreEmpty && v.isEmpty()) && !(dedup && list.contains(v))) {
+                list.add(v);
+            }
         }
         return Collections.unmodifiableList(list);
     }

--- a/core/src/test/java/io/github/jdbcx/UtilsTest.java
+++ b/core/src/test/java/io/github/jdbcx/UtilsTest.java
@@ -331,6 +331,24 @@ public class UtilsTest {
         Assert.assertEquals(Utils.split(" ", '\0'), Collections.singletonList(" "));
         Assert.assertEquals(Utils.split("a\0\0b", '\0'), Arrays.asList("a", "", "b"));
         Assert.assertEquals(Utils.split(",,,a,c,,b,,,", ','), Arrays.asList("", "", "", "a", "c", "", "b", "", ""));
+
+        Assert.assertEquals(Utils.split(null, '\0', true, true, true), Collections.emptyList());
+
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', false, false, false),
+                Arrays.asList("", "", "", "x ", "y ", "x", "Bcd", "", " "));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', true, false, false),
+                Arrays.asList("", "", "", "x", "y", "x", "Bcd", "", ""));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', false, true, false),
+                Arrays.asList("x ", "y ", "x", "Bcd", " "));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', false, false, true),
+                Arrays.asList("", "x ", "y ", "x", "Bcd", " "));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', true, true, false),
+                Arrays.asList("x", "y", "x", "Bcd"));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', false, true, true),
+                Arrays.asList("x ", "y ", "x", "Bcd", " "));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', true, false, true),
+                Arrays.asList("", "x", "y", "Bcd"));
+        Assert.assertEquals(Utils.split(",,,x ,y ,x,Bcd,, ", ',', true, true, true), Arrays.asList("x", "y", "Bcd"));
     }
 
     @Test(groups = { "unit" })

--- a/driver/src/main/java/io/github/jdbcx/DriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/DriverExtension.java
@@ -153,6 +153,10 @@ public interface DriverExtension extends Comparable<DriverExtension> {
             defined = manager.getConfig(getName(), id);
         }
 
+        final String overridableParams = (String) defined.remove(Option.OVERRIDEABLE_PARAMS.getName());
+        final List<String> overridables = Checker.isNullOrBlank(overridableParams) ? Collections.emptyList()
+                : Utils.split(overridableParams, ',', true, true, true);
+
         // ensures the configured properties won't be overrided
         Properties config = new Properties(props);
         for (Option option : getOptions(props)) {
@@ -160,6 +164,14 @@ public interface DriverExtension extends Comparable<DriverExtension> {
             Object value = defined.remove(name);
             config.put(name, value != null ? value : option.getDefaultValue());
         }
+
+        // and then the overridable properties
+        for (String s : overridables) {
+            if (config.getProperty(s) != null) {
+                defined.remove(s);
+            }
+        }
+
         if (!defined.isEmpty()) {
             config.putAll(defined);
         }

--- a/driver/src/test/java/io/github/jdbcx/extension/WebDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/WebDriverExtensionTest.java
@@ -85,6 +85,23 @@ public class WebDriverExtensionTest extends BaseIntegrationTest {
         }
     }
 
+    @Test(groups = { "integration" })
+    public void testDryRunWithCustomParams() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("jdbcx.base.dir", "target/test-classes/config");
+        try (Connection conn = DriverManager.getConnection("jdbcx:", props);
+                Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt
+                    .executeQuery("{{ web.my-service(api.requestor=you,api.key=123,exec.dryrun=true): abc }}")) {
+                Assert.assertTrue(rs.next(), "Should have at least one row");
+                Assert.assertEquals(rs.getString("request"), "{\"requestor\":\"you\",\"message\":\"abc\"}");
+                Assert.assertEquals(rs.getString("headers"),
+                        "{Authorization=Bearer secret-key, Content-Type=application/json}");
+                Assert.assertFalse(rs.next(), "Should have only one row");
+            }
+        }
+    }
+
     @Test(groups = { "private" })
     public void testCustomUrlTemplate() throws SQLException {
         Properties props = new Properties();

--- a/driver/src/test/resources/config/web/my-service.properties
+++ b/driver/src/test/resources/config/web/my-service.properties
@@ -1,0 +1,14 @@
+# extension properties
+base.url=https://my.company.com
+url.template=${base.url}/${api.path}
+request.headers=Content-Type=application/json,Authorization=Bearer ${api.key}
+request.template={"requestor":"${api.requestor}","message":${}}
+request.encode=json
+result.json.path=response.content
+
+overrideable.params=api.path,api.requestor
+
+# custom properties
+api.path=service
+api.key=secret-key
+api.requestor=me


### PR DESCRIPTION
Add `overrideable.params` to define a list of parameters that can be overridden in query.