### PR TITLE
add query extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build & Test Docker Image
         run: |
           docker build --build-arg JDBCX_VERSION=latest -t jdbcx:ci . \
-          && docker run --rm jdbcx:ci 'jdbcx:sqlite::memory:' 'select {{script:1}}, {{shell:echo 2}}, {{prql:3}}'
+          && docker run --rm jdbcx:ci 'jdbcx:sqlite::memory:' 'select {{script:1}}, {{shell:echo 2}}, {{db:select 3}}'
 
   test-jdk21-linux:
     needs: compile

--- a/core/src/main/java/io/github/jdbcx/Compression.java
+++ b/core/src/main/java/io/github/jdbcx/Compression.java
@@ -85,7 +85,13 @@ public enum Compression {
         return Compression.getProvider(this);
     }
 
-    static CompressionProvider getProvider(Compression compress) {
+    /**
+     * Gets provider for the given compression.
+     *
+     * @param compress the given compression
+     * @return non-null provider for compressing and decompressing
+     */
+    public static CompressionProvider getProvider(Compression compress) {
         if (compress == null || compress == Compression.NONE) {
             return NoneSupport.getInstance();
         }

--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -95,43 +95,54 @@ public final class Option implements Serializable {
      * Whether to perform a dry run.
      */
     public static final Option EXEC_DRYRUN = Option
-            .of(new String[] { "exec.dryrun", "Whether to perform a dry run without actual execution.",
-                    Constants.FALSE_EXPR, Constants.TRUE_EXPR });
+            .ofBool("exec.dryrun", "Whether to perform a dry run without actual execution.", false);
     /**
      * The error handling approach to use when an execution fails.
      */
     public static final Option EXEC_ERROR = Option
             .of(new String[] { "exec.error", "The error handling strategy to use when execution fails.",
-                    ERROR_HANDLING_WARN, ERROR_HANDLING_IGNORE, ERROR_HANDLING_RETURN, ERROR_HANDLING_THROW });
+                    ERROR_HANDLING_THROW, ERROR_HANDLING_WARN, ERROR_HANDLING_IGNORE, ERROR_HANDLING_RETURN });
     /**
      * The maximum number of threads that can be used for query execution. 0
      * enforces sequential execution.
      */
-    public static final Option EXEC_PARALLELISM = Option.of(new String[] { "exec.parallelism",
+    public static final Option EXEC_PARALLELISM = Option.ofInt("exec.parallelism",
             "The maximum number of threads to use for parallel query execution. 0 enforces sequential, single-threaded execution.",
-            "0" });
+            0);
     /**
      * The priority for executing the query.
      */
-    public static final Option EXEC_PRIORITY = Option
-            .of(new String[] { "exec.priority",
-                    "Priority for query execution. Higher integer values indicate higher priority.", "5" });
+    public static final Option EXEC_PRIORITY = Option.ofInt("exec.priority",
+            "Priority for query execution. Higher integer values indicate higher priority.", 5);
     /**
      * The execution timeout in milliseconds.
      */
-    public static final Option EXEC_TIMEOUT = Option.of("exec.timeout",
-            "Execution timeout in milliseconds. A negative value or 0 disables the timeout.", "0");
+    public static final Option EXEC_TIMEOUT = Option.ofInt("exec.timeout",
+            "Execution timeout in milliseconds. A negative value or 0 disables the timeout.", 0);
 
-    public static final Option WORK_DIRECTORY = Option.of("work.dir",
-            "Path to the working directory. If left empty, the current directory will be used.",
-            Constants.EMPTY_STRING);
+    public static final Option WORK_DIRECTORY = Option.ofOptional("work.dir",
+            "Path to the working directory. If left empty, the current directory will be used.");
 
     public static final Option INPUT_FILE = Option
-            .of(new String[] { "input.file",
-                    "Path to an input file containing the query text to be executed. Utilizing this property will omit any inline query content." });
+            .ofOptional("input.file",
+                    "Path to an input file containing the query text to be executed. Utilizing this property will omit any inline query content.");
+    public static final Option INTPUT_FILE_EXIST = Option.ofBool("input.file.exist",
+            "Throw error if input does not exist", true);
     public static final Option OUTPUT_FILE = Option
-            .of(new String[] { "output.file",
-                    "Path to an output file for writing query results. If the file already exists, it will be overwritten without warning." });
+            .ofOptional("output.file",
+                    "Path to an output file for writing query results. If the file already exists, it will be overwritten without warning.");
+    public static final Option OUTPUT_FILE_OVERRIDE = Option.ofBool("output.file.override",
+            "Override if the output file already exists", true);
+    public static final Option OUTPUT_FILE_COMPRESS_ALGORITHM = Option
+            .ofEnum("output.file.compress.algorithm", "Compression alogirhtm used for the output file.",
+                    Compression.NONE.name(), Compression.class);
+    public static final Option OUTPUT_FILE_COMPRESS_BUFFER = Option.ofInt("output.file.compress.buffer",
+            "Buffer size for compression", 0);
+    public static final Option OUTPUT_FILE_COMPRESS_LEVEL = Option.ofInt("output.file.compress.level",
+            "Compression level which is different for different algorithms.", -1);
+    public static final Option OUTPUT_FILE_COMPRESS_PARAMS = Option.ofOptional("output.file.compress.params",
+            "Additional comma seperated parameters for compression.");
+
     public static final Option INPUT_CHARSET = Option.of("input.charset",
             "Character encoding to use when reading the input stream.", Constants.DEFAULT_CHARSET.name());
     public static final Option OUTPUT_CHARSET = Option.of("output.charset",
@@ -387,6 +398,12 @@ public final class Option implements Serializable {
         return of(info[0], description, defaultValue, choices);
     }
 
+    public static Option ofBool(String name, String description, boolean defaultValue) {
+        return of(new String[] { name, description,
+                defaultValue ? Constants.TRUE_EXPR : Constants.FALSE_EXPR,
+                defaultValue ? Constants.FALSE_EXPR : Constants.TRUE_EXPR });
+    }
+
     /**
      * Creates an option.
      *
@@ -410,6 +427,14 @@ public final class Option implements Serializable {
         }
 
         return of(name, description, defaultValue, arr);
+    }
+
+    public static Option ofInt(String name, String description, int defaultValue) {
+        return of(name, description, String.valueOf(defaultValue));
+    }
+
+    public static Option ofOptional(String name, String description) {
+        return of(name, description, Constants.EMPTY_STRING);
     }
 
     /**

--- a/core/src/main/java/io/github/jdbcx/QueryContext.java
+++ b/core/src/main/java/io/github/jdbcx/QueryContext.java
@@ -43,6 +43,10 @@ public final class QueryContext implements AutoCloseable, Serializable {
      */
     public static final String KEY_CONNECTION = "connection";
     /**
+     * Key for function to get JDBCX wrapped {@link java.sql.Connection}.
+     */
+    public static final String KEY_WRAPPED_CONNECTION = "wrappedConnection";
+    /**
      * Key for JDBC dialect.
      */
     public static final String KEY_DIALECT = "dialect";

--- a/core/src/main/java/io/github/jdbcx/QueryGroup.java
+++ b/core/src/main/java/io/github/jdbcx/QueryGroup.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This class represents a group of queries.
+ */
+public final class QueryGroup {
+    static final String QUERY_DELIMITER = "--;; ";
+
+    static final String PREFIX = QueryGroup.class.getSimpleName() + " #";
+    static final String SOURCE = " in [";
+    static final int BUFFER = PREFIX.length() + SOURCE.length() + 5;
+
+    /**
+     * Splits the query into zero or more groups separated by
+     * {@code ^--;; <comments>$}.
+     *
+     * @param query the original query
+     * @return non-null list of query groups
+     */
+    public static List<QueryGroup> of(String query) {
+        if (Checker.isNullOrEmpty(query)) {
+            return Collections.emptyList();
+        }
+
+        final int dlen = QUERY_DELIMITER.length();
+        final int len = query.length();
+        final List<QueryGroup> list = new LinkedList<>();
+
+        int lastIndex = 0;
+        String comment = Constants.EMPTY_STRING;
+        for (int i = 0; i < len; i++) {
+            int index = query.indexOf(QUERY_DELIMITER, i);
+            if (index == -1) { // last group
+                String subQuery = query.substring(i).trim();
+                if (!subQuery.isEmpty()) {
+                    list.add(new QueryGroup(list.size(), comment, subQuery));
+                }
+                lastIndex = -1;
+            } else if (index == lastIndex || query.charAt(index - 1) == '\n') { // new group
+                if (index > lastIndex) { // might be a valid query
+                    String subQuery = query.substring(lastIndex, index - 1).trim();
+                    if (!subQuery.isEmpty()) {
+                        list.add(new QueryGroup(list.size(), comment, subQuery));
+                    }
+                }
+                index += dlen;
+                // now update comment
+                int idx = query.indexOf('\n', index);
+                if (idx != -1) {
+                    comment = query.substring(index, idx).trim();
+                    i = idx; // NOSONAR
+                    lastIndex = idx + 1;
+                } else {
+                    comment = query.substring(index).trim();
+                    lastIndex = -1;
+                }
+            }
+
+            if (lastIndex == -1) {
+                break;
+            }
+        }
+
+        if (lastIndex > 0) {
+            String subQuery = query.substring(lastIndex).trim();
+            if (!subQuery.isEmpty()) {
+                list.add(new QueryGroup(list.size(), comment, subQuery));
+            }
+        }
+
+        return Collections.unmodifiableList(list);
+    }
+
+    private final int index;
+    private final String description;
+    private final String query;
+
+    public QueryGroup(int index, String description, String query) {
+        this.index = index >= 0 ? index : 0;
+        this.description = description != null ? description : Constants.EMPTY_STRING;
+        this.query = query != null ? query : Constants.EMPTY_STRING;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = index;
+        result = prime * result + description.hashCode();
+        result = prime * result + query.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        QueryGroup other = (QueryGroup) obj;
+        return index == other.index && description.equals(other.description) && query.equals(other.query);
+    }
+
+    public String toString(String source) {
+        final int descLength = description.length();
+        final int srcLength = source.length();
+
+        final StringBuilder builder = new StringBuilder(BUFFER + descLength + srcLength);
+        builder.append(PREFIX).append(index + 1);
+        if (descLength > 0) {
+            builder.append(' ').append(description);
+        }
+        if (srcLength > 0) {
+            builder.append(SOURCE).append(source).append(']');
+        }
+        return builder.toString();
+    }
+}

--- a/core/src/main/java/io/github/jdbcx/QueryTask.java
+++ b/core/src/main/java/io/github/jdbcx/QueryTask.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.github.jdbcx.executor.Stream;
+
+/**
+ * This class represents a query task.
+ */
+public final class QueryTask {
+    public static List<QueryTask> ofQuery(String query) {
+        final List<QueryTask> list = new LinkedList<>();
+        for (QueryGroup g : QueryGroup.of(query)) {
+            list.add(new QueryTask(Constants.EMPTY_STRING, Collections.singletonList(g)));
+        }
+        return list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(list);
+    }
+
+    public static List<QueryTask> ofFile(String file, Charset charset) {
+        if (Checker.isNullOrEmpty(file)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            final List<QueryTask> list = new LinkedList<>();
+            for (QueryGroup g : QueryGroup.of(Stream.readAllAsString(new FileInputStream(file), charset))) {
+                list.add(new QueryTask(file, Collections.singletonList(g)));
+            }
+            return list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(list);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static List<QueryTask> ofPath(String path, Charset charset) {
+        final List<Path> paths;
+        try {
+            paths = Utils.findFiles(path, null);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(Utils.format("Failed to extract files from given path [%s]", path),
+                    e);
+        }
+
+        final int pathCount = paths.size();
+        final List<QueryTask> tasks;
+        if (pathCount == 0) {
+            tasks = Collections.emptyList();
+        } else if (pathCount == 1) {
+            tasks = ofFile(paths.get(0).toString(), charset);
+        } else {
+            List<QueryTask> list = new ArrayList<>(pathCount);
+            try {
+                for (Path p : paths) {
+                    String file = p.toString();
+                    list.add(new QueryTask(file,
+                            QueryGroup.of(Stream.readAllAsString(new FileInputStream(file), charset))));
+                }
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+            tasks = list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(list);
+        }
+        return tasks;
+    }
+
+    private final String source;
+    private final List<QueryGroup> groups;
+
+    public QueryTask(String source, List<QueryGroup> groups) {
+        this.source = source != null ? source : Constants.EMPTY_STRING;
+        this.groups = groups != null ? groups : Collections.emptyList();
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public List<QueryGroup> getGroups() {
+        return groups;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = source.hashCode();
+        result = prime * result + groups.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        QueryTask other = (QueryTask) obj;
+        return source.equals(other.source) && groups.equals(other.groups);
+    }
+}

--- a/core/src/main/java/io/github/jdbcx/executor/AbstractExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/AbstractExecutor.java
@@ -175,6 +175,7 @@ abstract class AbstractExecutor implements Executor {
     protected final boolean defaultDryRun;
     protected final String defaultErrorHandling;
     protected final String defaultInputFile;
+    protected final String defaultOutputFile;
     protected final Charset defaultInputCharset;
     protected final Charset defaultOutputCharset;
     protected final int defaultParallelism;
@@ -191,6 +192,7 @@ abstract class AbstractExecutor implements Executor {
         this.defaultDryRun = Boolean.parseBoolean(Option.EXEC_DRYRUN.getValue(props));
         this.defaultErrorHandling = Option.EXEC_ERROR.getValue(props);
         this.defaultInputFile = Option.INPUT_FILE.getValue(props);
+        this.defaultOutputFile = Option.OUTPUT_FILE.getValue(props);
         this.defaultInputCharset = Checker.isNullOrBlank(inputCharset) ? Charset.forName(inputCharset)
                 : Constants.DEFAULT_CHARSET;
         this.defaultOutputCharset = Checker.isNullOrBlank(outputCharset) ? Charset.forName(outputCharset)

--- a/core/src/main/java/io/github/jdbcx/executor/FileConfiguration.java
+++ b/core/src/main/java/io/github/jdbcx/executor/FileConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.executor;
+
+import java.util.Properties;
+
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Format;
+
+final class FileConfiguration {
+    final String name;
+    final Format format;
+    final Properties params;
+    final Compression compressionAlg;
+    final int compressionLevel;
+    final int compressionBuffer;
+
+    FileConfiguration(String name, Format format, Properties params, Compression compressionAlg, int compressionLevel,
+            int compressionBuffer) {
+        this.name = name;
+        this.format = format;
+        this.params = params;
+        this.compressionAlg = compressionAlg;
+        this.compressionLevel = compressionLevel;
+        this.compressionBuffer = compressionBuffer;
+    }
+}

--- a/core/src/main/java/io/github/jdbcx/executor/QueryExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/QueryExecutor.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.executor;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Compression;
+import io.github.jdbcx.Constants;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Logger;
+import io.github.jdbcx.LoggerFactory;
+import io.github.jdbcx.Option;
+import io.github.jdbcx.QueryGroup;
+import io.github.jdbcx.QueryTask;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.Row;
+import io.github.jdbcx.Utils;
+import io.github.jdbcx.VariableTag;
+
+public class QueryExecutor extends AbstractExecutor {
+    private static final Logger log = LoggerFactory.getLogger(QueryExecutor.class);
+
+    private static final List<Field> dryRunFields = Collections
+            .unmodifiableList(Arrays.asList(Field.of("path"), FIELD_QUERY, FIELD_OPTIONS));
+    private static final List<Field> resultFields = Collections
+            .unmodifiableList(
+                    Arrays.asList(Field.of("thread"), Field.of("connection", JDBCType.INTEGER), Field.of("source"),
+                            Field.of("group", JDBCType.INTEGER), FIELD_QUERY, Field.of("query_count", JDBCType.BIGINT),
+                            Field.of("update_count", JDBCType.BIGINT), Field.of("total_operations", JDBCType.BIGINT),
+                            Field.of("affected_rows", JDBCType.BIGINT), Field.of("elapsed_ms", JDBCType.BIGINT)));
+
+    public static final Option OPTION_PATH = Option.of(new String[] { "path", "File path(s) (supports globbing)" });
+
+    static long[] execute(Connection conn, String query, FileConfiguration conf) throws SQLException {
+        if (query.isEmpty()) {
+            return new long[] { 0L, 0L };
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            boolean hasResultSet = stmt.execute(query);
+            long affectedRows = !hasResultSet ? Utils.getAffectedRows(stmt) : -1L;
+            long reads = 0L;
+            long updates = 0L;
+            long rows = affectedRows > 0L ? affectedRows : 0L;
+            while (true) {
+                if (hasResultSet) {
+                    try (ResultSet rs = stmt.getResultSet()) {
+                        if (conf != null && !conf.name.isEmpty()) {
+                            try (OutputStream out = Compression.getProvider(conf.compressionAlg)
+                                    .compress(new FileOutputStream(conf.name), conf.compressionLevel,
+                                            conf.compressionBuffer)) {
+                                Result.writeTo(Result.of(rs), conf.format, conf.params, out);
+                            }
+                        }
+                    } catch (IOException e) {
+                        throw new SQLException(e);
+                    }
+                    reads++;
+                } else {
+                    updates++;
+                }
+
+                try {
+                    if (!(hasResultSet = stmt.getMoreResults())) { // NOSONAR
+                        if ((affectedRows = Utils.getAffectedRows(stmt)) == -1L) {
+                            break;
+                        } else {
+                            rows += affectedRows;
+                        }
+                    }
+                } catch (SQLFeatureNotSupportedException | UnsupportedOperationException e) {
+                    break;
+                }
+            }
+
+            return new long[] { reads, updates, rows };
+        }
+    }
+
+    static List<Row> executeQueries(List<QueryTask> tasks, Connection conn, FileConfiguration conf,
+            AtomicBoolean failedRef) throws SQLException {
+        final String thread = Thread.currentThread().getName();
+        final int connection = conn.hashCode();
+        final List<Row> results = new LinkedList<>();
+
+        String currentSource = Constants.EMPTY_STRING;
+        QueryGroup currentGroup = null;
+        try {
+            for (QueryTask t : tasks) {
+                currentSource = t.getSource();
+                for (QueryGroup g : t.getGroups()) {
+                    currentGroup = g;
+                    if (failedRef != null && failedRef.get()) {
+                        return Collections.emptyList(); // fail fast
+                    }
+
+                    final String queryInfo = g.toString(t.getSource());
+                    log.debug("Executing %s...", queryInfo);
+
+                    final long startTime = System.currentTimeMillis();
+                    final long[] rounds = execute(conn, g.getQuery(), conf);
+                    final long reads = rounds[0];
+                    final long updates = rounds[1];
+                    final long total = reads + updates;
+                    final long rows = rounds[2];
+                    final long elapsed = System.currentTimeMillis() - startTime;
+                    log.debug("Completed %s (%,d reads, %,d updates) in %,d ms", queryInfo, reads, updates, elapsed);
+                    if (total < 1) {
+                        if (failedRef != null) {
+                            failedRef.compareAndSet(false, true);
+                        }
+                        return Collections.emptyList();
+                    }
+                    results.add(Row.of(resultFields,
+                            new Object[] { thread, connection, t.getSource(), g.getIndex() + 1, g.getDescription(),
+                                    reads, updates, total, rows, elapsed }));
+                }
+            }
+        } catch (SQLException e) {
+            throw currentGroup != null
+                    ? new SQLException(Utils.format("Failed to execute %s",
+                            currentGroup.toString(currentSource)), e)
+                    : e;
+        } finally {
+            Utils.closeQuietly(conn);
+        }
+        return results;
+    }
+
+    protected final String defaultPath;
+
+    public QueryExecutor(VariableTag tag, Properties props) {
+        super(tag, props);
+
+        this.defaultPath = OPTION_PATH.getValue(props, Constants.EMPTY_STRING);
+    }
+
+    public String getPath(Properties props) {
+        return Utils.normalizePath(Utils.applyVariables(OPTION_PATH.getValue(props, defaultPath),
+                VariableTag.valueOf(Option.TAG.getValue(props)), props)).trim();
+    }
+
+    public Result<?> execute(String query, Supplier<Connection> manager, Properties props) throws SQLException {
+        if (getDryRun(props)) {
+            return Result.of(Row.of(dryRunFields, new Object[] { getPath(props), query, props }));
+        }
+
+        final String path = getPath(props);
+        final List<QueryTask> tasks;
+        if (Checker.isNullOrEmpty(path)) {
+            final String inputFile = getInputFile(props);
+            if (Checker.isNullOrEmpty(inputFile)) {
+                tasks = QueryTask.ofQuery(query);
+            } else {
+                tasks = QueryTask.ofFile(inputFile, getInputCharset(props));
+            }
+        } else {
+            tasks = QueryTask.ofPath(path, getInputCharset(props));
+        }
+
+        if (tasks.isEmpty()) {
+            return Result.of(resultFields);
+        }
+
+        final int parallel = getParallelism(props);
+        final List<Row> results;
+        if (parallel <= 1) {
+            results = executeQueries(tasks, manager.get(), null, null);
+        } else {
+            final AtomicBoolean failedRef = new AtomicBoolean(false);
+            final ExecutorService threadPool = newThreadPool(this, parallel, -1);
+            final List<CompletableFuture<Void>> futures = new LinkedList<>();
+
+            results = Collections.synchronizedList(new LinkedList<>());
+            try {
+                for (QueryTask t : tasks) {
+                    futures.add(CompletableFuture.runAsync(() -> {
+                        try {
+                            results.addAll(
+                                    executeQueries(Collections.singletonList(t), manager.get(), null, failedRef));
+                        } catch (Exception e) {
+                            throw new IllegalStateException(e);
+                        }
+                    }, threadPool));
+                }
+                threadPool.shutdown();
+
+                while (!futures.isEmpty()) {
+                    boolean cancel = false;
+                    for (Iterator<CompletableFuture<Void>> it = futures.iterator(); it.hasNext();) {
+                        CompletableFuture<Void> future = it.next();
+                        if (cancel) {
+                            future.cancel(true);
+                            it.remove();
+                        } else if (future.isDone()) {
+                            it.remove();
+                            try {
+                                future.get();
+                            } catch (InterruptedException e) {
+                                failedRef.compareAndSet(false, cancel = true);
+                                log.warn("Query is interrupted", e);
+                            } catch (CancellationException e) {
+                                failedRef.compareAndSet(false, cancel = true);
+                                log.warn("Query is cancelled", e);
+                            } catch (ExecutionException e) {
+                                failedRef.compareAndSet(false, cancel = true);
+                                log.error("Abort query due to execution failure", e.getCause());
+                            }
+                        }
+                    }
+                    Thread.sleep(100L);
+                }
+            } catch (InterruptedException e) {
+                // ignore
+                log.warn("Query execution has been interrupted. It may take sometime to shutdown all running tasks.",
+                        e);
+                Thread.currentThread().interrupt();
+            } finally {
+                threadPool.shutdownNow();
+            }
+
+            if (failedRef.get()) {
+                throw new SQLException("Query failed, please check logs for details");
+            }
+        }
+        return Result.of(resultFields, results);
+    }
+}

--- a/core/src/main/java/io/github/jdbcx/executor/QueryExecutor.java
+++ b/core/src/main/java/io/github/jdbcx/executor/QueryExecutor.java
@@ -251,7 +251,6 @@ public class QueryExecutor extends AbstractExecutor {
                 Thread.currentThread().interrupt();
             } finally {
                 threadPool.shutdownNow();
-                Utils.closeQuietly(threadPool);
             }
 
             if (failedRef.get()) {

--- a/core/src/main/java/io/github/jdbcx/interpreter/QueryInterpreter.java
+++ b/core/src/main/java/io/github/jdbcx/interpreter/QueryInterpreter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.interpreter;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import io.github.jdbcx.Option;
+import io.github.jdbcx.QueryContext;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.executor.QueryExecutor;
+
+public class QueryInterpreter extends AbstractInterpreter {
+    public static final List<Option> OPTIONS = Collections
+            .unmodifiableList(Arrays.asList(QueryExecutor.OPTION_PATH, Option.INPUT_FILE));
+
+    private final QueryExecutor executor;
+
+    public QueryInterpreter(QueryContext context, Properties config) {
+        super(context);
+
+        executor = new QueryExecutor(getVariableTag(), config);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Result<?> interpret(String query, Properties props) {
+        try {
+            return executor.execute(query, (Supplier<Connection>) getContext().get(QueryContext.KEY_WRAPPED_CONNECTION),
+                    props);
+        } catch (Exception e) {
+            return handleError(e, query, props);
+        }
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/OptionTest.java
+++ b/core/src/test/java/io/github/jdbcx/OptionTest.java
@@ -75,6 +75,21 @@ public class OptionTest {
     }
 
     @Test(groups = { "unit" })
+    public void testOfBool() {
+        Option option = Option.ofBool("b1", null, true);
+        Assert.assertEquals(option.getName(), "b1");
+        Assert.assertEquals(option.getDescription(), "");
+        Assert.assertEquals(option.getDefaultValue(), Constants.TRUE_EXPR);
+        Assert.assertEquals(option.getChoices(), new String[] { Constants.TRUE_EXPR, Constants.FALSE_EXPR });
+
+        option = Option.ofBool("b2", "test", false);
+        Assert.assertEquals(option.getName(), "b2");
+        Assert.assertEquals(option.getDescription(), "test");
+        Assert.assertEquals(option.getDefaultValue(), Constants.FALSE_EXPR);
+        Assert.assertEquals(option.getChoices(), new String[] { Constants.FALSE_EXPR, Constants.TRUE_EXPR });
+    }
+
+    @Test(groups = { "unit" })
     public void testOfEnum() {
         Option option = Option.ofEnum("n", null, null, null);
         Assert.assertEquals(option.getDefaultValue(), "");
@@ -95,6 +110,36 @@ public class OptionTest {
         option = Option.ofEnum("n", null, "LZ4", Compression.class);
         Assert.assertEquals(option.getDefaultValue(), Compression.LZ4.name());
         Assert.assertEquals(option.getChoices().length, Compression.values().length);
+    }
+
+    @Test(groups = { "unit" })
+    public void testOfInt() {
+        Option option = Option.ofInt("i1", null, 3);
+        Assert.assertEquals(option.getName(), "i1");
+        Assert.assertEquals(option.getDescription(), "");
+        Assert.assertEquals(option.getDefaultValue(), "3");
+        Assert.assertEquals(option.getChoices(), new String[0]);
+
+        option = Option.ofInt("i2", "test", -1);
+        Assert.assertEquals(option.getName(), "i2");
+        Assert.assertEquals(option.getDescription(), "test");
+        Assert.assertEquals(option.getDefaultValue(), "-1");
+        Assert.assertEquals(option.getChoices(), new String[0]);
+    }
+
+    @Test(groups = { "unit" })
+    public void testOfOptional() {
+        Option option = Option.ofOptional("o1", null);
+        Assert.assertEquals(option.getName(), "o1");
+        Assert.assertEquals(option.getDescription(), "");
+        Assert.assertEquals(option.getDefaultValue(), "");
+        Assert.assertEquals(option.getChoices(), new String[0]);
+
+        option = Option.ofOptional("o2", "test");
+        Assert.assertEquals(option.getName(), "o2");
+        Assert.assertEquals(option.getDescription(), "test");
+        Assert.assertEquals(option.getDefaultValue(), "");
+        Assert.assertEquals(option.getChoices(), new String[0]);
     }
 
     @Test(groups = { "unit" })

--- a/core/src/test/java/io/github/jdbcx/QueryGroupTest.java
+++ b/core/src/test/java/io/github/jdbcx/QueryGroupTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QueryGroupTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        QueryGroup group = new QueryGroup(-1, null, null);
+        Assert.assertEquals(group.getIndex(), 0);
+        Assert.assertEquals(group.getDescription(), "");
+        Assert.assertEquals(group.getQuery(), "");
+        Assert.assertEquals(group, new QueryGroup(0, "", ""));
+    }
+
+    @Test(groups = { "unit" })
+    public void testEquals() {
+        QueryGroup group = new QueryGroup(7, "q2", "select 5");
+        Assert.assertEquals(group, new QueryGroup(7, new StringBuilder().append('q').append(2).toString(),
+                new StringBuilder().append("select ").append(5).toString()));
+
+        Assert.assertNotEquals(group, new QueryGroup(6, "q2", "select 5"));
+        Assert.assertNotEquals(group, new QueryGroup(7, "q1", "select 5"));
+        Assert.assertNotEquals(group, new QueryGroup(7, "q2", "select 2"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testSplit() {
+        Assert.assertEquals(QueryGroup.of(null), Collections.emptyList());
+        Assert.assertEquals(QueryGroup.of(""), Collections.emptyList());
+
+        Assert.assertEquals(QueryGroup.of("select 1"), Collections.singletonList(new QueryGroup(0, null, "select 1")));
+        Assert.assertEquals(QueryGroup.of("select 1;\nselect 2\n"),
+                Collections.singletonList(new QueryGroup(0, null, "select 1;\nselect 2")));
+
+        Assert.assertEquals(QueryGroup.of("--;; q1\nselect 1\n--;; q2\nselect 2"),
+                Arrays.asList(new QueryGroup(0, "q1", "select 1"), new QueryGroup(1, "q2", "select 2")));
+        Assert.assertEquals(QueryGroup.of("select 1\n--;; q2\nselect 2"),
+                Arrays.asList(new QueryGroup(0, "", "select 1"), new QueryGroup(1, "q2", "select 2")));
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/QueryTaskTest.java
+++ b/core/src/test/java/io/github/jdbcx/QueryTaskTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QueryTaskTest {
+    @Test(groups = { "unit" })
+    public void testOfQuery() {
+        Assert.assertEquals(QueryTask.ofQuery(null), Collections.emptyList());
+        Assert.assertEquals(QueryTask.ofQuery(""), Collections.emptyList());
+
+        final String select1 = "select 1";
+        Assert.assertEquals(QueryTask.ofQuery(select1), Collections
+                .singletonList(new QueryTask("", Collections.singletonList(new QueryGroup(0, null, select1)))));
+        Assert.assertEquals(QueryTask.ofQuery("--;; q1\n" + select1), Collections
+                .singletonList(new QueryTask("", Collections.singletonList(new QueryGroup(0, "q1", select1)))));
+        Assert.assertEquals(QueryTask.ofQuery("--;; q1\n" + select1 + "\n--;; q2\n" + select1),
+                Arrays.asList(new QueryTask("",
+                        Collections.singletonList(new QueryGroup(0, "q1", select1))),
+                        new QueryTask("", Collections.singletonList(new QueryGroup(1, "q2", select1)))));
+    }
+
+    @Test(groups = { "unit" })
+    public void testOfFile() {
+        Assert.assertEquals(QueryTask.ofFile(null, null), Collections.emptyList());
+        Assert.assertEquals(QueryTask.ofFile("", null), Collections.emptyList());
+
+        Assert.assertEquals(QueryTask.ofFile("target/test-classes/queries/empty_query.sql", null),
+                Collections.emptyList());
+        List<QueryTask> list = QueryTask.ofFile("target/test-classes/queries/select_7.sql", null);
+        Assert.assertEquals(list, Collections
+                .singletonList(new QueryTask(list.get(0).getSource(),
+                        Collections.singletonList(new QueryGroup(0, null, "select 7")))));
+        list = QueryTask.ofFile("target/test-classes/queries/two_queries.sql", null);
+        Assert.assertEquals(list, Arrays.asList(new QueryTask(list.get(0).getSource(),
+                Collections.singletonList(new QueryGroup(0, "query #1", "select 1"))),
+                new QueryTask(list.get(0).getSource(),
+                        Collections.singletonList(new QueryGroup(1, "query #2", "select 2")))));
+    }
+
+    @Test(groups = { "unit" })
+    public void testOfPath() {
+        Assert.assertEquals(QueryTask.ofPath(null, null), Collections.emptyList());
+        Assert.assertEquals(QueryTask.ofPath("", null), Collections.emptyList());
+
+        Assert.assertEquals(QueryTask.ofPath("target/test-classes/queries/empty_query.?ql", null),
+                Collections.emptyList());
+        List<QueryTask> list = QueryTask.ofPath("target/test-classes/queries/select_7.*", null);
+        Assert.assertEquals(list, Collections
+                .singletonList(new QueryTask(list.get(0).getSource(),
+                        Collections.singletonList(new QueryGroup(0, null, "select 7")))));
+        list = QueryTask.ofPath("target/test-classes/queries/two_querie?.*", null);
+        Assert.assertEquals(list, Arrays.asList(new QueryTask(list.get(0).getSource(),
+                Collections.singletonList(new QueryGroup(0, "query #1", "select 1"))),
+                new QueryTask(list.get(0).getSource(),
+                        Collections.singletonList(new QueryGroup(1, "query #2", "select 2")))));
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/executor/QueryExecutorTest.java
+++ b/core/src/test/java/io/github/jdbcx/executor/QueryExecutorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.executor;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.BaseIntegrationTest;
+import io.github.jdbcx.Option;
+import io.github.jdbcx.executor.jdbc.ReadOnlyResultSet;
+
+public class QueryExecutorTest extends BaseIntegrationTest {
+    @Test(groups = { "unit" })
+    public void testConstructor() {
+        Assert.assertNotNull(new QueryExecutor(null, null));
+        Assert.assertNotNull(new QueryExecutor(null, new Properties()));
+    }
+
+    @Test(groups = { "integration" })
+    public void testPath() throws SQLException {
+        Properties props = new Properties();
+        final String url = "jdbc:mysql://root@" + getMySqlServer() + "?allowMultiQueries=true";
+        final String query = "select 1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            Option.INPUT_FILE.setValue(props, "target/test-classes/non-existent.file");
+            props.setProperty("path", "target/test-classes/queries/*.non-existent");
+            QueryExecutor exec = new QueryExecutor(null, props);
+            try (ResultSet rs = new ReadOnlyResultSet(null, exec.execute(query, () -> conn, props))) {
+                Assert.assertFalse(rs.next(), "Should not have any result");
+            }
+        }
+
+        try (Connection conn = DriverManager.getConnection(url)) {
+            props.setProperty("path", "target/test-classes/queries/*_7.sql");
+            QueryExecutor exec = new QueryExecutor(null, props);
+            try (ResultSet rs = new ReadOnlyResultSet(null, exec.execute(query, () -> conn, props))) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+                Assert.assertEquals(rs.getInt("connection"), conn.hashCode());
+                Assert.assertTrue(rs.getString("source").endsWith("select_7.sql"));
+                Assert.assertEquals(rs.getInt("group"), 1);
+                Assert.assertEquals(rs.getString("query"), "");
+                Assert.assertEquals(rs.getLong("query_count"), 1L);
+                Assert.assertEquals(rs.getLong("update_count"), 0L);
+                Assert.assertEquals(rs.getLong("total_operations"), 1L);
+                Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+                Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testInputFile() throws SQLException {
+        Properties props = new Properties();
+        final String query = "select 1";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "?allowMultiQueries=true")) {
+            Option.INPUT_FILE.setValue(props, "target/test-classes/non-existent.file");
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> new QueryExecutor(null, props).execute("query", () -> conn, props));
+
+            Option.INPUT_FILE.setValue(props, "target/test-classes/queries/select_7.sql");
+            QueryExecutor exec = new QueryExecutor(null, props);
+            try (ResultSet rs = new ReadOnlyResultSet(null, exec.execute(query, () -> conn, props))) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+                Assert.assertEquals(rs.getInt("connection"), conn.hashCode());
+                Assert.assertTrue(rs.getString("source").endsWith("select_7.sql"));
+                Assert.assertEquals(rs.getInt("group"), 1);
+                Assert.assertEquals(rs.getString("query"), "");
+                Assert.assertEquals(rs.getLong("query_count"), 1L);
+                Assert.assertEquals(rs.getLong("update_count"), 0L);
+                Assert.assertEquals(rs.getLong("total_operations"), 1L);
+                Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+                Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testInlineQuery() throws SQLException {
+        Properties props = new Properties();
+
+        final String query = "--;; my query\nselect 1; select 2 n union select 3 order by 1; select 4 n union select 5 union select 6 order by 1";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "?allowMultiQueries=true")) {
+            QueryExecutor exec = new QueryExecutor(null, props);
+            try (ResultSet rs = new ReadOnlyResultSet(null, exec.execute(query, () -> conn, props))) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+                Assert.assertEquals(rs.getInt("connection"), conn.hashCode());
+                Assert.assertTrue(rs.getString("source").endsWith(""));
+                Assert.assertEquals(rs.getInt("group"), 1);
+                Assert.assertEquals(rs.getString("query"), "my query");
+                Assert.assertEquals(rs.getLong("query_count"), 3L);
+                Assert.assertEquals(rs.getLong("update_count"), 0L);
+                Assert.assertEquals(rs.getLong("total_operations"), 3L);
+                Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+                Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testInlineUpdate() throws SQLException {
+        Properties props = new Properties();
+
+        final String query = "--;; my update\ncreate table if not exists test_multi_update_counts(i INTEGER); insert into test_multi_update_counts values(1); "
+                + "insert into test_multi_update_counts values(2),(3); insert into test_multi_update_counts values(4),(5),(6)";
+        try (Connection conn = DriverManager
+                .getConnection("jdbc:mysql://root@" + getMySqlServer() + "/mysql?allowMultiQueries=true")) {
+            QueryExecutor exec = new QueryExecutor(null, props);
+            try (ResultSet rs = new ReadOnlyResultSet(null, exec.execute(query, () -> conn, props))) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+                Assert.assertEquals(rs.getInt("connection"), conn.hashCode());
+                Assert.assertTrue(rs.getString("source").endsWith(""));
+                Assert.assertEquals(rs.getInt("group"), 1);
+                Assert.assertEquals(rs.getString("query"), "my update");
+                Assert.assertEquals(rs.getLong("query_count"), 0L);
+                Assert.assertEquals(rs.getLong("update_count"), 4L);
+                Assert.assertEquals(rs.getLong("total_operations"), 4L);
+                Assert.assertEquals(rs.getLong("affected_rows"), 6L);
+                Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+                Assert.assertFalse(rs.next());
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/interpreter/AbstractInterpreterTest.java
+++ b/core/src/test/java/io/github/jdbcx/interpreter/AbstractInterpreterTest.java
@@ -77,7 +77,7 @@ public class AbstractInterpreterTest {
     @Test(groups = { "unit" })
     public void testHandleError() {
         final TestInterpreter i = new TestInterpreter(QueryContext.newContext());
-        Assert.assertThrows(NullPointerException.class, () -> i.handleError(null, null, null, null));
+        Assert.assertThrows(CompletionException.class, () -> i.handleError(null, null, null, null));
         Assert.assertThrows(CompletionException.class, () -> i.handleError(new Exception(), null, null, null));
 
         Properties props = new Properties();

--- a/core/src/test/resources/queries/two_queries.sql
+++ b/core/src/test/resources/queries/two_queries.sql
@@ -1,0 +1,5 @@
+--;; query #1
+select 1
+
+--;; query #2
+select 2

--- a/driver/src/main/java/io/github/jdbcx/DriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/DriverExtension.java
@@ -89,7 +89,19 @@ public interface DriverExtension extends Comparable<DriverExtension> {
             }
         }
 
-        if (extension != null && extension != DefaultDriverExtension.getInstance()) {
+        if (extension == DefaultDriverExtension.getInstance()) {
+            final int len = Option.PROPERTY_PREFIX.length();
+            for (Entry<Object, Object> entry : properties.entrySet()) {
+                String key = entry.getKey().toString();
+                if (key.startsWith(Option.PROPERTY_PREFIX)) {
+                    String name = key.substring(len);
+                    Object val = entry.getValue();
+                    if (val != null) {
+                        props.put(name, val);
+                    }
+                }
+            }
+        } else if (extension != null) {
             Properties p = extension.getDefaultConfig();
             final String prefix = new StringBuilder(Option.PROPERTY_PREFIX).append(extension.getName()).append('.')
                     .toString();

--- a/driver/src/main/java/io/github/jdbcx/driver/WrappedConnection.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/WrappedConnection.java
@@ -105,7 +105,7 @@ public class WrappedConnection implements ManagedConnection {
             this.warning = wrappedConn.warning;
         } else {
             this.manager = new ConnectionManager(info.configManager, info.getExtensions(), info.extension, conn, url,
-                    info.extensionProps, info.normalizedInfo, info.mergedInfo);
+                    info.extensionProps, info.normalizedInfo, info.normalizedUrl, info.mergedInfo);
             this.warning = new AtomicReference<>();
         }
     }

--- a/driver/src/main/java/io/github/jdbcx/driver/impl/DefaultConnection.java
+++ b/driver/src/main/java/io/github/jdbcx/driver/impl/DefaultConnection.java
@@ -99,7 +99,7 @@ public final class DefaultConnection extends DefaultResource implements ManagedC
         this.schema = new AtomicReference<>();
 
         this.manager = new ConnectionManager(configManager, extensions, defaultExtension, this, url, extensionProps,
-                normalizedProps, originalProps);
+                normalizedProps, url, originalProps);
 
         this.url = url;
     }

--- a/driver/src/main/java/io/github/jdbcx/extension/QueryDriverExtension.java
+++ b/driver/src/main/java/io/github/jdbcx/extension/QueryDriverExtension.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.extension;
+
+import java.sql.Connection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import io.github.jdbcx.ConfigManager;
+import io.github.jdbcx.DriverExtension;
+import io.github.jdbcx.JdbcActivityListener;
+import io.github.jdbcx.Option;
+import io.github.jdbcx.QueryContext;
+import io.github.jdbcx.interpreter.QueryInterpreter;
+
+public final class QueryDriverExtension implements DriverExtension {
+    static class ActivityListener extends AbstractActivityListener {
+        ActivityListener(QueryContext context, Properties config) {
+            super(new QueryInterpreter(context, config), config);
+        }
+    }
+
+    @Override
+    public List<String> getAliases() {
+        return Collections.singletonList("queries");
+    }
+
+    @Override
+    public List<Option> getDefaultOptions() {
+        return QueryInterpreter.OPTIONS;
+    }
+
+    @Override
+    public JdbcActivityListener createListener(QueryContext context, Connection conn, Properties props) {
+        return new ActivityListener(context, getConfig((ConfigManager) context.get(QueryContext.KEY_CONFIG), props));
+    }
+
+    @Override
+    public String getDescription() {
+        return "Extension to execute one or more files";
+    }
+
+    @Override
+    public String getUsage() {
+        return "{{ query(path=~/scripts/*.sql) }}";
+    }
+
+    @Override
+    public boolean supportsNoArguments() {
+        return true;
+    }
+}

--- a/driver/src/main/resources/META-INF/services/io.github.jdbcx.DriverExtension
+++ b/driver/src/main/resources/META-INF/services/io.github.jdbcx.DriverExtension
@@ -4,6 +4,7 @@ io.github.jdbcx.extension.CodeQLDriverExtension
 io.github.jdbcx.extension.DbDriverExtension
 io.github.jdbcx.extension.PromptDriverExtension
 io.github.jdbcx.extension.PrqlDriverExtension
+io.github.jdbcx.extension.QueryDriverExtension
 io.github.jdbcx.extension.ScriptDriverExtension
 io.github.jdbcx.extension.ShellDriverExtension
 io.github.jdbcx.extension.VarDriverExtension

--- a/driver/src/test/java/io/github/jdbcx/DriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/DriverExtensionTest.java
@@ -92,12 +92,16 @@ public class DriverExtensionTest {
         Assert.assertEquals(DriverExtension.extractProperties(DefaultDriverExtension.getInstance(), props), expected);
 
         props.setProperty("jdbcx.custom.property2", "value2");
+        expected.setProperty("custom.property2", "value2");
         Assert.assertEquals(DriverExtension.extractProperties(DefaultDriverExtension.getInstance(), props), expected);
 
         props.setProperty("jdbcx.prql.cli.path", "/path/to/prqlc");
+        expected.setProperty("prql.cli.path", "/path/to/prqlc");
         Assert.assertEquals(DriverExtension.extractProperties(DefaultDriverExtension.getInstance(), props), expected);
 
         PrqlDriverExtension ext = new PrqlDriverExtension();
+        expected.remove("custom.property2");
+        expected.remove("prql.cli.path");
         expected.putAll(ext.getDefaultConfig());
         expected.setProperty("cli.path", "/path/to/prqlc");
         Assert.assertEquals(DriverExtension.extractProperties(ext, props), expected);

--- a/driver/src/test/java/io/github/jdbcx/MainTest.java
+++ b/driver/src/test/java/io/github/jdbcx/MainTest.java
@@ -15,10 +15,8 @@
  */
 package io.github.jdbcx;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -111,18 +109,6 @@ public class MainTest {
 
         Assert.assertNotEquals(args.queries, newArgs.queries);
         Assert.assertEquals(newArgs.queries.toArray(new String[1][]), new String[][] { { "1", "q1" } });
-    }
-
-    @Test(groups = { "unit" })
-    public void testCloseConnection() throws SQLException {
-        Main.closeQuietly(null);
-        Main.closeQuietly(new ByteArrayInputStream(new byte[1]));
-
-        try (Connection conn = DriverManager.getConnection(DEFAULT_CONNECTION_URL, new Properties())) {
-            Assert.assertFalse(conn.isClosed());
-            Main.closeQuietly(conn);
-            Assert.assertTrue(conn.isClosed());
-        }
     }
 
     @Test(groups = { "unit" })

--- a/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
+++ b/driver/src/test/java/io/github/jdbcx/WrappedDriverTest.java
@@ -143,7 +143,9 @@ public class WrappedDriverTest extends BaseIntegrationTest {
             Assert.assertThrows(SQLException.class, () -> stmt.executeQuery("helper.invalidMethod()"));
         }
 
-        try (Connection conn = d.connect(url, null);
+        Properties props = new Properties();
+        props.setProperty("jdbcx.script.exec.error", "warn");
+        try (Connection conn = d.connect(url, props);
                 Statement stmt = conn.createStatement();
                 ResultSet rs = stmt.executeQuery("select '3'")) {
             Assert.assertTrue(rs.next(), "Should have at least one row in result");
@@ -151,7 +153,7 @@ public class WrappedDriverTest extends BaseIntegrationTest {
             Assert.assertFalse(rs.next(), "Should have ONLY one row in result");
         }
 
-        Properties props = new Properties();
+        props = new Properties();
         props.setProperty("jdbcx.script.exec.error", "throw");
         try (Connection conn = d.connect(url, props); Statement stmt = conn.createStatement();) {
             Assert.assertThrows(SQLException.class, () -> stmt.executeQuery("helper.invalidMethod()"));
@@ -174,6 +176,7 @@ public class WrappedDriverTest extends BaseIntegrationTest {
             Assert.assertNotNull(stmt.getWarnings(), "Should have SQLWarning");
             Assert.assertFalse(rs.next(), "Should NOT have any result");
         }
+        props.setProperty("jdbcx.script.exec.error", "warn");
         try (Connection conn = d.connect(url, props);
                 Statement stmt = conn.createStatement();
                 ResultSet rs = stmt.executeQuery("select 5")) {

--- a/driver/src/test/java/io/github/jdbcx/driver/impl/DefaultConnectionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/driver/impl/DefaultConnectionTest.java
@@ -46,6 +46,7 @@ public class DefaultConnectionTest {
     @Test(groups = { "unit" })
     public void testChangeCatalog() throws SQLException {
         Properties props = new Properties();
+        props.setProperty("jdbcx.exec.error", "warn");
         WrappedDriver d = new WrappedDriver();
 
         try (Connection conn = d.connect("jdbcx:", props)) {

--- a/driver/src/test/java/io/github/jdbcx/extension/BridgeDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/BridgeDriverExtensionTest.java
@@ -89,6 +89,7 @@ public class BridgeDriverExtensionTest {
         Properties props = new Properties();
         props.setProperty("_secret1_", "xxx");
         props.setProperty("_secret2_", "***");
+        props.setProperty("exec.error", "warn");
         try (Connection conn = DriverManager.getConnection("jdbcx:db:sqlite::memory:", props);
                 QueryContext context = QueryContext.newContext()) {
             BridgeDriverExtension ext = new BridgeDriverExtension();

--- a/driver/src/test/java/io/github/jdbcx/extension/DbDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/DbDriverExtensionTest.java
@@ -32,8 +32,10 @@ import io.github.jdbcx.WrappedDriver;
 public class DbDriverExtensionTest extends BaseIntegrationTest {
     @Test(groups = { "integration" })
     public void testQuery() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("jdbcx.db.exec.error", "warn");
         final String address = getClickHouseServer();
-        try (Connection conn = DriverManager.getConnection("jdbcx:db:ch://" + address);
+        try (Connection conn = DriverManager.getConnection("jdbcx:db:ch://" + address, props);
                 Statement stmt = conn.createStatement()) {
             try (ResultSet rs = stmt.executeQuery("select 1")) {
                 Assert.assertTrue(rs.next(), "Should have at least one row");
@@ -42,7 +44,8 @@ public class DbDriverExtensionTest extends BaseIntegrationTest {
             }
 
             try (ResultSet rs = stmt
-                    .executeQuery("select '{{ db(url='jdbc:ch://${ch.server.address}'): select ''${_}:${_.url}'', 2}}'")) {
+                    .executeQuery(
+                            "select '{{ db(url='jdbc:ch://${ch.server.address}'): select ''${_}:${_.url}'', 2}}'")) {
                 Assert.assertNotNull(stmt.getWarnings());
                 Assert.assertTrue(rs.next(), "Should have at least one row");
                 Assert.assertEquals(rs.getString(1), "select 'db:jdbc:ch://${ch.server.address}', 2");
@@ -50,7 +53,7 @@ public class DbDriverExtensionTest extends BaseIntegrationTest {
             }
         }
 
-        Properties props = new Properties();
+        props = new Properties();
         props.setProperty("jdbcx.db.ch.server.address", address);
         try (Connection conn = DriverManager.getConnection("jdbcx:ch://" + address, props);
                 Statement stmt = conn.createStatement()) {

--- a/driver/src/test/java/io/github/jdbcx/extension/QueryDriverExtensionTest.java
+++ b/driver/src/test/java/io/github/jdbcx/extension/QueryDriverExtensionTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.extension;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.BaseIntegrationTest;
+import io.github.jdbcx.WrappedDriver;
+
+public class QueryDriverExtensionTest extends BaseIntegrationTest {
+    @Test(groups = { "integration" })
+    public void testPath() throws SQLException {
+        Properties props = new Properties();
+        WrappedDriver driver = new WrappedDriver();
+
+        final String testQuery = "{{ query(path=target/test-classes/test-queries/sequential/*ddl.*,input.file=omitted): omitted }}";
+        try (Connection conn = driver.connect("jdbcx:sqlite::memory:", props);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(testQuery)) {
+            Assert.assertTrue(rs.next(), "Should have at least one row");
+            final int firstConnectionId = rs.getInt("connection");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertNotEquals(firstConnectionId, conn.hashCode());
+            Assert.assertNotEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 1);
+            Assert.assertEquals(rs.getString("query"), "create table test_queries_g1t1");
+            Assert.assertEquals(rs.getLong("query_count"), 0L);
+            Assert.assertEquals(rs.getLong("update_count"), 1L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertTrue(rs.next(), "Should have at least two rows");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertEquals(rs.getInt("connection"), firstConnectionId);
+            Assert.assertNotEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 2);
+            Assert.assertEquals(rs.getString("query"), "create table test_queries_g1t2");
+            Assert.assertEquals(rs.getLong("query_count"), 0L);
+            Assert.assertEquals(rs.getLong("update_count"), 1L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertFalse(rs.next(), "Should have only 2 rows");
+        }
+
+        for (int i = 0; i < 10; i++) {
+            try (Connection conn = driver.connect("jdbcx:sqlite::memory:", props);
+                    Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery(
+                            "{{ query(path=target/test-classes/test-queries/sequential/??ddl.*,exec.parallelism="
+                                    + i + ") }}")) {
+                Assert.assertTrue(rs.next(), "Should have at least one row when parallelism=" + i);
+                Assert.assertTrue(rs.next(), "Should have at least two rows when parallelism=" + i);
+                Assert.assertFalse(rs.next(), "Should have only 2 rows when parallelism=" + i);
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testInputFile() throws SQLException {
+        Properties props = new Properties();
+        WrappedDriver driver = new WrappedDriver();
+
+        final String testQuery = "{{ query(input.file=target/test-classes/test-queries/sequential/1_ddl.sql): inline query is omitted }}";
+        try (Connection conn = driver.connect("jdbcx:sqlite::memory:", props);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(testQuery)) {
+            Assert.assertTrue(rs.next(), "Should have at least one row");
+            final int firstConnectionId = rs.getInt("connection");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertNotEquals(firstConnectionId, conn.hashCode());
+            Assert.assertTrue(rs.getString("source").endsWith("1_ddl.sql"));
+            Assert.assertEquals(rs.getInt("group"), 1);
+            Assert.assertEquals(rs.getString("query"), "create table test_queries_g1t1");
+            Assert.assertEquals(rs.getLong("query_count"), 0L);
+            Assert.assertEquals(rs.getLong("update_count"), 1L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertTrue(rs.next(), "Should have at least two rows");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertEquals(rs.getInt("connection"), firstConnectionId);
+            Assert.assertTrue(rs.getString("source").endsWith("1_ddl.sql"));
+            Assert.assertEquals(rs.getInt("group"), 2);
+            Assert.assertEquals(rs.getString("query"), "create table test_queries_g1t2");
+            Assert.assertEquals(rs.getLong("query_count"), 0L);
+            Assert.assertEquals(rs.getLong("update_count"), 1L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertFalse(rs.next(), "Should have only 2 rows");
+        }
+
+        for (int i = 0; i < 10; i++) {
+            try (Connection conn = driver.connect("jdbcx:sqlite::memory:", props);
+                    Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery(
+                            "{{ query(input.file=target/test-classes/test-queries/sequential/1_ddl.sql,exec.parallelism="
+                                    + i + ") }}")) {
+                Assert.assertTrue(rs.next(), "Should have at least one row when parallelism=" + i);
+                Assert.assertTrue(rs.getString("source").endsWith("1_ddl.sql"));
+                Assert.assertTrue(rs.next(), "Should have at least two rows when parallelism=" + i);
+                Assert.assertTrue(rs.getString("source").endsWith("1_ddl.sql"));
+                Assert.assertFalse(rs.next(), "Should have only 2 rows when parallelism=" + i);
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testInlineQuery() throws SQLException {
+        Properties props = new Properties();
+        WrappedDriver driver = new WrappedDriver();
+        try (Connection conn = driver.connect("jdbcx:", props);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("{{ query: test }}")) {
+            Assert.assertTrue(rs.next(), "Should have at least one row");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertNotEquals(rs.getInt("connection"), conn.hashCode());
+            Assert.assertEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 1);
+            Assert.assertEquals(rs.getString("query"), "");
+            Assert.assertEquals(rs.getLong("query_count"), 1L);
+            Assert.assertEquals(rs.getLong("update_count"), 0L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+            Assert.assertFalse(rs.next(), "Should have only one row");
+        }
+
+        final String multiStatementQuery = "--;; 1st query\nselect 1\n--;; 2nd query \nselect 2\n"
+                + "--;;  1st update \ncreate table a(b String) engine=Memory;\ninsert into a values('x'),('y')";
+        try (Connection conn = driver.connect("jdbcx:ch://" + getClickHouseServer(), props);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "{{ query:\n" + multiStatementQuery + " }}")) {
+            Assert.assertTrue(rs.next(), "Should have at least one row");
+            final int firstConnectionId = rs.getInt("connection");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertNotEquals(firstConnectionId, conn.hashCode());
+            Assert.assertEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 1);
+            Assert.assertEquals(rs.getString("query"), "1st query");
+            Assert.assertEquals(rs.getLong("query_count"), 1L);
+            Assert.assertEquals(rs.getLong("update_count"), 0L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertTrue(rs.next(), "Should have at least two rows");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertEquals(rs.getInt("connection"), firstConnectionId);
+            Assert.assertEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 2);
+            Assert.assertEquals(rs.getString("query"), "2nd query");
+            Assert.assertEquals(rs.getLong("query_count"), 1L);
+            Assert.assertEquals(rs.getLong("update_count"), 0L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 0L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertTrue(rs.next(), "Should have at least three rows");
+            Assert.assertEquals(rs.getString("thread"), Thread.currentThread().getName());
+            Assert.assertEquals(rs.getInt("connection"), firstConnectionId);
+            Assert.assertEquals(rs.getString("source"), "");
+            Assert.assertEquals(rs.getInt("group"), 3);
+            Assert.assertEquals(rs.getString("query"), "1st update");
+            Assert.assertEquals(rs.getLong("query_count"), 0L);
+            Assert.assertEquals(rs.getLong("update_count"), 1L);
+            Assert.assertEquals(rs.getLong("total_operations"), 1L);
+            Assert.assertEquals(rs.getLong("affected_rows"), 2L);
+            Assert.assertTrue(rs.getLong("elapsed_ms") >= 0L);
+
+            Assert.assertFalse(rs.next(), "Should have only 3 rows");
+        }
+    }
+}


### PR DESCRIPTION
* add query extension
  ```sql
  {{ query:
  --;; query group #1
  select 1; select 2
  --;; query group #2
  select 3
  }}
  
  {{ query(input.file=~/specific.sql }}
  
  {{ query(path=~/*.sql }}
  ```
* change default value of exec.error from warn to throw
* stop using hard-coded timeout for retrieving bridge server config

Will raise separate PRs to refactor Main (to use newly added query extension instead for consistency), and output file support.