### PR TITLE
add new format and server endpoints

### DIFF
--- a/core/src/main/java/io/github/jdbcx/Format.java
+++ b/core/src/main/java/io/github/jdbcx/Format.java
@@ -39,6 +39,7 @@ public enum Format {
     BSON(false, false, false, "application/bson", "bson"),
     JSONL(false, false, false, "application/jsonl", "jsonl"), // or application/json-lines?
     JSON_SEQ(false, false, false, "application/json-seq", "jsons"), // mainly for streaming, seldom used
+    MARKDOWN(false, false, false, "text/markdown", "md"),
     NDJSON(false, false, false, "application/x-ndjson", "ndjson"), // same as JSONL
     // https://issues.apache.org/jira/browse/PARQUET-1889
     PARQUET(true, true, true, "application/vnd.apache.parquet", "parquet"),

--- a/core/src/main/java/io/github/jdbcx/Option.java
+++ b/core/src/main/java/io/github/jdbcx/Option.java
@@ -72,6 +72,7 @@ public final class Option implements Serializable {
 
     // most common options
     public static final Option ID = Option.of(new String[] { "id", "ID for looking up configuration" });
+    public static final Option DESCRIPTION = Option.of(new String[] { "description", "Description" });
     public static final Option CLASSPATH = Option
             .of(new String[] { "classpath", "Comma separated classpath for loading classes" });
 

--- a/core/src/main/java/io/github/jdbcx/Result.java
+++ b/core/src/main/java/io/github/jdbcx/Result.java
@@ -45,6 +45,7 @@ import io.github.jdbcx.format.AvroSerde;
 import io.github.jdbcx.format.BsonSerde;
 import io.github.jdbcx.format.CsvSerde;
 import io.github.jdbcx.format.JsonlSerde;
+import io.github.jdbcx.format.MarkdownSerde;
 import io.github.jdbcx.format.JsonSeqSerde;
 import io.github.jdbcx.format.ParquetSerde;
 import io.github.jdbcx.format.TsvSerde;
@@ -211,6 +212,9 @@ public final class Result<T> implements AutoCloseable {
                 break;
             case JSON_SEQ:
                 serde = new JsonSeqSerde(config);
+                break;
+            case MARKDOWN:
+                serde = new MarkdownSerde(config);
                 break;
             case PARQUET:
                 serde = new ParquetSerde(config);

--- a/core/src/main/java/io/github/jdbcx/Utils.java
+++ b/core/src/main/java/io/github/jdbcx/Utils.java
@@ -1103,6 +1103,8 @@ public final class Utils {
     public static List<String> split(String str, char delimiter, boolean trim, boolean ignoreEmpty, boolean dedup) {
         if (str == null) {
             return Collections.emptyList();
+        } else if (trim) {
+            str = str.trim();
         }
 
         List<String> list = new LinkedList<>();
@@ -1125,8 +1127,8 @@ public final class Utils {
         }
 
         if (list.isEmpty()) {
-            return Collections.singletonList(str);
-        } else if (builder.length() > 0) {
+            return ignoreEmpty && str.isEmpty() ? Collections.emptyList() : Collections.singletonList(str);
+        } else if (builder.length() > 0 || str.charAt(str.length() - 1) == delimiter) {
             String v = builder.toString();
             if (trim) {
                 v = v.trim();

--- a/core/src/main/java/io/github/jdbcx/config/PropertyFileConfigManager.java
+++ b/core/src/main/java/io/github/jdbcx/config/PropertyFileConfigManager.java
@@ -17,6 +17,7 @@ package io.github.jdbcx.config;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -254,21 +255,25 @@ public class PropertyFileConfigManager extends ConfigManager {
             props = new Properties();
             final Path baseDir = path.get();
             Path p = baseDir.resolve(getUniqueId(category, id).concat(FILE_EXTENSION));
-            log.debug("Loading configuration [%s] from [%s]...", id, p);
+            log.debug("Loading configuration of named %s [%s] from [%s]...", category, id, p);
             try (Reader reader = new InputStreamReader(new FileInputStream(p.toFile()), Constants.DEFAULT_CHARSET)) {
                 props.load(reader);
                 props.remove(Option.ID.getJdbcxName());
                 if (props.getProperty(Option.ID.getName()) != null) {
                     Option.ID.setValue(props, id);
                 }
+            } catch (FileNotFoundException e) {
+                throw new IllegalArgumentException(
+                        Utils.format("Named %s [%s] does not exist", category, id), e);
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to load configuration", e);
+                throw new IllegalArgumentException(
+                        Utils.format("Failed to load configuration of named %s [%s]", category, id), e);
             }
         }
 
         if (props == null) {
             throw new IllegalArgumentException(
-                    Utils.format("Could not find configuration [category=%s, id=%s]", category, id));
+                    Utils.format("Could not find configuration for named %s [%s]", category, id));
         }
         return props;
     }

--- a/core/src/main/java/io/github/jdbcx/format/MarkdownSerde.java
+++ b/core/src/main/java/io/github/jdbcx/format/MarkdownSerde.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.format;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.List;
+import java.util.Properties;
+
+import io.github.jdbcx.Checker;
+import io.github.jdbcx.Constants;
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.Row;
+import io.github.jdbcx.Value;
+
+public class MarkdownSerde extends TextSerde {
+    static final String MARKDOWN_RESERVED_CHARS = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
+    static final String NEW_LINE = "<br/>";
+    static final String COLUMN_BEGIN = "| ";
+    static final String COLUMN_END = " |";
+    static final String COLUMN_SEP = " | ";
+    static final String COLUMN_NEW = "\n|";
+
+    static final String ALIGNMENT_LEFT = ":-|";
+    static final String ALIGHMENT_RIGHT = "-:|";
+
+    static final Properties update(Properties config) {
+        Properties newConf = new Properties(config);
+        if (Checker.isNullOrEmpty(OPTION_HEADER.getValue(newConf))) {
+            OPTION_HEADER.setValue(newConf, Constants.TRUE_EXPR);
+        }
+        return newConf;
+    }
+
+    public MarkdownSerde(Properties config) {
+        super(update(config));
+    }
+
+    protected String encode(String str) {
+        if (str == null) {
+            return nullValue;
+        } else {
+            int len = str.length();
+            StringBuilder builder = new StringBuilder(len);
+            for (int i = 0; i < len; i++) {
+                char ch = str.charAt(i);
+                if (ch == '\r') {
+                    // skip
+                } else if (ch == '\n') {
+                    builder.append(NEW_LINE);
+                } else if (MARKDOWN_RESERVED_CHARS.indexOf(ch) != -1) {
+                    builder.append('\\').append(ch);
+                } else {
+                    builder.append(ch);
+                }
+            }
+            return builder.toString();
+        }
+    }
+
+    protected void writeHeader(List<Field> fields, int size, Writer writer) throws IOException {
+        writer.write(COLUMN_BEGIN);
+        StringBuilder builder = new StringBuilder(size * 2 + 2).append(COLUMN_NEW);
+        if (size-- > 1) {
+            for (int i = 0; i < size; i++) {
+                Field f = fields.get(i);
+                writer.write(encode(f.name()));
+                writer.write(COLUMN_SEP);
+                builder.append(f.scale() > 0 ? ALIGHMENT_RIGHT : ALIGNMENT_LEFT);
+            }
+        }
+        Field f = fields.get(size);
+        writer.write(encode(f.name()));
+        builder.append(f.scale() > 0 ? ALIGHMENT_RIGHT : ALIGNMENT_LEFT);
+        writer.write(COLUMN_END);
+        writer.write(builder.toString());
+    }
+
+    protected void writeRow(Row r, int size, Writer writer) throws IOException {
+        writer.write(COLUMN_BEGIN);
+        if (size-- > 1) {
+            for (int i = 0; i < size; i++) {
+                Value v = r.value(i);
+                writer.write(encode(v.isNull() ? null : v.asString(charset)));
+                writer.write(COLUMN_SEP);
+            }
+        }
+        Value v = r.value(size);
+        writer.write(encode(v.isNull() ? null : v.asString(charset)));
+        writer.write(COLUMN_END);
+    }
+
+    @Override
+    public Result<?> deserialize(Reader reader) throws IOException {
+        throw new UnsupportedOperationException("Unimplemented method 'deserialize'");
+    }
+
+    @Override
+    public void serialize(Result<?> result, Writer writer) throws IOException {
+        final List<Field> fields = result.fields();
+        final int size = fields.size();
+
+        if (header) {
+            writeHeader(fields, size, writer);
+            for (Row r : result.rows()) {
+                writer.write('\n');
+                writeRow(r, size, writer);
+            }
+        } else {
+            boolean notFirst = false;
+            for (Row r : result.rows()) {
+                if (notFirst) {
+                    writer.write('\n');
+                } else {
+                    notFirst = true;
+                }
+                writeRow(r, size, writer);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/github/jdbcx/UtilsTest.java
+++ b/core/src/test/java/io/github/jdbcx/UtilsTest.java
@@ -331,11 +331,14 @@ public class UtilsTest {
     public void testSplitByChar() {
         Assert.assertEquals(Utils.split(null, '\0'), Collections.emptyList());
         Assert.assertEquals(Utils.split("", '\0'), Collections.singletonList(""));
-        Assert.assertEquals(Utils.split(" ", ' '), Arrays.asList(""));
+        Assert.assertEquals(Utils.split(" ", ' '), Arrays.asList("", ""));
+        Assert.assertEquals(Utils.split(" ", ' ', true, false, false), Arrays.asList(""));
+
+        Assert.assertEquals(Utils.split("", ',', true, true, true), Collections.emptyList());
 
         Assert.assertEquals(Utils.split(" ", '\0'), Collections.singletonList(" "));
         Assert.assertEquals(Utils.split("a\0\0b", '\0'), Arrays.asList("a", "", "b"));
-        Assert.assertEquals(Utils.split(",,,a,c,,b,,,", ','), Arrays.asList("", "", "", "a", "c", "", "b", "", ""));
+        Assert.assertEquals(Utils.split(",,,a,c,,b,,,", ','), Arrays.asList("", "", "", "a", "c", "", "b", "", "", ""));
 
         Assert.assertEquals(Utils.split(null, '\0', true, true, true), Collections.emptyList());
 

--- a/core/src/test/java/io/github/jdbcx/format/MarkdownSerdeTest.java
+++ b/core/src/test/java/io/github/jdbcx/format/MarkdownSerdeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-2025, Zhichun Wu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jdbcx.format;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.github.jdbcx.Field;
+import io.github.jdbcx.Result;
+import io.github.jdbcx.Serialization;
+
+public class MarkdownSerdeTest {
+    @Test(groups = { "unit" })
+    public void testSerialize() throws IOException {
+        final Result<?> result = Result.of(Arrays.asList(Field.of("a,b"), Field.of("|c")), new Object[][] {
+                { null, null }, { "1,2\n3", "," }
+        });
+        final String expected = "| a\\,b | \\|c |\n|:-|:-|\n|  |  |\n| 1\\,2<br/>3 | \\, |";
+
+        Properties config = new Properties();
+        Serialization serde = new MarkdownSerde(config);
+        Charset charset = ((MarkdownSerde) serde).charset;
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            serde.serialize(result, out);
+            Assert.assertEquals(new String(out.toByteArray(), charset), expected);
+        }
+
+        TextSerde.OPTION_HEADER.setValue(config, "false");
+        serde = new MarkdownSerde(config);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            serde.serialize(result, out);
+            Assert.assertEquals(new String(out.toByteArray(), charset), "|  |  |\n| 1\\,2<br/>3 | \\, |");
+        }
+    }
+}

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -370,7 +370,6 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
             }
         } catch (Exception e) {
             // ignore
-            e.printStackTrace();
         }
         writer.write('}');
     }

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -699,8 +699,14 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         try {
             conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db"), config, headers);
             Assert.assertEquals(conn.getResponseCode(), 200);
-            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()),
-                    "[{\"id\":\"my-duckdb\",\"description\":\"Local DuckDB for testing purpose\"},{\"id\":\"my-sqlite\",\"description\":\"SQLite for local development\"}]");
+            String actual = Stream.readAllAsString(conn.getInputStream());
+            Assert.assertTrue(actual.startsWith("[") && actual.endsWith("]"), "Should be a JSON array");
+            Assert.assertTrue(
+                    actual.indexOf("{\"id\":\"my-duckdb\",\"description\":\"Local DuckDB for testing purpose\"}") > 0,
+                    "Should have my-duckdb");
+            Assert.assertTrue(
+                    actual.indexOf("{\"id\":\"my-sqlite\",\"description\":\"SQLite for local development\"}") > 0,
+                    "Should have sqlite");
         } finally {
             if (conn != null) {
                 conn.disconnect();

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -594,7 +594,8 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
 
         try (Connection conn = DriverManager.getConnection("jdbcx:", props);
                 Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("insert into my_table {{ values.db.my-sqlite: select 1 a, '${_.id}.${_}' B }}")) {
+                ResultSet rs = stmt
+                        .executeQuery("insert into my_table {{ values.db.my-sqlite: select 1 a, '${_.id}.${_}' B }}")) {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getString(1), "insert into my_table (\"a\",\"B\") VALUES\n(1,'my-sqlite.db')");
             Assert.assertFalse(rs.next());
@@ -685,6 +686,112 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
                     }
                     Assert.assertFalse(rs.next(), "Should NOT have more records");
                 }
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testNamedDataSources() throws Exception {
+        Properties config = new Properties();
+        Map<String, String> headers = new HashMap<>();
+        WebExecutor web = new WebExecutor(VariableTag.BRACE, config);
+        HttpURLConnection conn = null;
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db"), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), 200);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()),
+                    "[{\"id\":\"my-duckdb\",\"description\":\"Local DuckDB for testing purpose\"},{\"id\":\"my-sqlite\",\"description\":\"SQLite for local development\"}]");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/script"), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), 200);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "[]");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/notsupported"), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), 200);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "[]");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testDataSourceConfig() throws Exception {
+        Properties config = new Properties();
+        Map<String, String> headers = new HashMap<>();
+        WebExecutor web = new WebExecutor(VariableTag.BRACE, config);
+        HttpURLConnection conn = null;
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db/nonexist"), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), 200);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "{}");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db/my-sqlite"), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), 200);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()),
+                    "{\"id\":\"my-sqlite\",\"aliases\":[\"local-sqlite\",\"private-sqlite\"],\"description\":,\"SQLite for local development\"}");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testErrorMessage() throws Exception {
+        Properties config = new Properties();
+        Map<String, String> headers = new HashMap<>();
+        WebExecutor web = new WebExecutor(VariableTag.BRACE, config);
+        HttpURLConnection conn = null;
+        for (String p : new String[] { "error", "error/", "error/123" }) {
+            try {
+                conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + p), config, headers);
+                Assert.assertEquals(conn.getResponseCode(), 404);
+            } finally {
+                if (conn != null) {
+                    conn.disconnect();
+                }
+            }
+        }
+
+        final String queryId = UUID.randomUUID().toString();
+        try {
+            conn = web.openConnection(
+                    Utils.toURL(this.server.getBaseUrl() + "async/" + queryId + ".csv?q="
+                            + Utils.encode("{{db.nonexist: select1}}")),
+                    config, headers);
+            Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_INTERNAL_ERROR);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+        try {
+            conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "error/" + queryId), config, headers);
+            Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "Named db [nonexist] does not exist");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
             }
         }
     }

--- a/server/src/test/resources/config/db/my-duckdb.properties
+++ b/server/src/test/resources/config/db/my-duckdb.properties
@@ -1,1 +1,3 @@
 jdbcx.url=jdbc:duckdb:
+jdbcx.alias=local-duckdb
+jdbcx.description=Local DuckDB for testing purpose

--- a/server/src/test/resources/config/db/my-sqlite.properties
+++ b/server/src/test/resources/config/db/my-sqlite.properties
@@ -1,1 +1,3 @@
 jdbcx.url=jdbc:sqlite::memory:
+jdbcx.alias=local-sqlite, private-sqlite
+jdbcx.description=SQLite for local development


### PR DESCRIPTION
* fix bug in `Utils.split` method
* improve error message when named datasource does not exist
* stop logging access token for security reason
* add markdown support
* add the following new endpoints in bridge server
  - `/config/<extension>`: list named datasources of the extension in a JSON array
  - `/config/<extension>/<id>`: get details of the named datasource as a JSON object
  - `/error/<query id>`: get error of the query
