### PR TITLE
enhance datasource inspection

### DIFF
--- a/driver/README.md
+++ b/driver/README.md
@@ -113,7 +113,7 @@ helper.format(
 )
 EOF
 java -Djdbcx.custom.classpath=`pwd` -jar jdbcx.jar \
-    'jdbcx:script:ch://explorer@play.clickhouse.com:443?ssl=true&compress=0' @my.js
+    'jdbcx:script:ch://localhost?ssl=true&compress=0' @my.js
 ```
 
 

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -368,9 +368,9 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
                 return;
             }
 
-            writer.write(',');
             ConfigManager manager = managedConn.getManager().getConfigManager();
             Properties props = manager.getConfig(extension, name);
+            writer.write(',');
             writer.write(JSON_PROP_ID);
             writer.write(JsonHelper.encode(name));
             String str = ConfigManager.OPTION_ALIAS.getJdbcxValue(props);
@@ -388,19 +388,22 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
 
             if (DB_EXTENSIONS.contains(extension)) {
                 try (Connection c = JdbcInterpreter.getConnectionByConfig(props, null)) {
-                    writer.write(',');
                     final DatabaseMetaData metaData = c.getMetaData();
                     str = JdbcInterpreter.getDatabaseProduct(metaData);
                     if (!Checker.isNullOrEmpty(str)) {
-                        writer.write(str);
                         writer.write(',');
+                        writer.write(str);
                     }
-                    writer.write(JdbcInterpreter.getDatabaseCatalogs(metaData, name,
-                            JdbcInterpreter.DEFAULT_TABLE_PATTERN, JdbcInterpreter.DEFAULT_TABLE_TYPES));
+                    str = JdbcInterpreter.getDatabaseCatalogs(metaData, name,
+                            JdbcInterpreter.DEFAULT_TABLE_PATTERN, JdbcInterpreter.DEFAULT_TABLE_TYPES);
+                    if (!Checker.isNullOrEmpty(str)) {
+                        writer.write(',');
+                        writer.write(str);
+                    }
                 }
             }
-        } catch (SQLException e) {
-            throw new IOException(e);
+        } catch (Exception e) {
+            log.warn("Failed to inspect datasource [%s].[%s]", extension, name, e);
         }
         writer.write('}');
     }

--- a/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
+++ b/server/src/main/java/io/github/jdbcx/server/BridgeServer.java
@@ -23,11 +23,13 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -66,6 +68,7 @@ import io.github.jdbcx.driver.ManagedConnection;
 import io.github.jdbcx.driver.QueryParser;
 import io.github.jdbcx.executor.JdbcExecutor;
 import io.github.jdbcx.executor.WebExecutor;
+import io.github.jdbcx.interpreter.JdbcInterpreter;
 import io.github.jdbcx.interpreter.JsonHelper;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
@@ -84,9 +87,14 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
 
     public static final String METHOD_HEAD = "HEAD";
 
+    public static final List<String> DB_EXTENSIONS = Collections.unmodifiableList(Arrays.asList("db", "sql"));
+
     public static final String JSON_PROP_ID = "\"id\":";
     public static final String JSON_PROP_ALIASES = "\"aliases\":";
     public static final String JSON_PROP_DESC = "\"description\":";
+    public static final String JSON_PROP_TYPE = "\"type\":";
+
+    // information_schema
 
     public static final String PATH_CONFIG = "config";
     public static final String PATH_ERROR = "error/";
@@ -354,21 +362,45 @@ public abstract class BridgeServer implements RemovalListener<String, QueryInfo>
         writer.write('{');
         try (Connection conn = datasource.getConnection()) {
             ManagedConnection managedConn = conn.unwrap(ManagedConnection.class);
-            if (managedConn != null) {
-                ConfigManager manager = managedConn.getManager().getConfigManager();
-                Properties props = manager.getConfig(extension, name);
-                writer.write(JSON_PROP_ID);
-                writer.write(JsonHelper.encode(name));
+            writer.write(JSON_PROP_TYPE);
+            writer.write(JsonHelper.encode(extension));
+            if (managedConn == null) {
+                return;
+            }
+
+            writer.write(',');
+            ConfigManager manager = managedConn.getManager().getConfigManager();
+            Properties props = manager.getConfig(extension, name);
+            writer.write(JSON_PROP_ID);
+            writer.write(JsonHelper.encode(name));
+            String str = ConfigManager.OPTION_ALIAS.getJdbcxValue(props);
+            if (!Checker.isNullOrEmpty(str)) {
                 writer.write(',');
                 writer.write(JSON_PROP_ALIASES);
-                writer.write(JsonHelper
-                        .encode(Utils.split(ConfigManager.OPTION_ALIAS.getJdbcxValue(props), ',', true, true, true)));
+                writer.write(JsonHelper.encode(Utils.split(str, ',', true, true, true)));
+            }
+            str = Option.DESCRIPTION.getJdbcxValue(props);
+            if (!Checker.isNullOrEmpty(str)) {
                 writer.write(',');
                 writer.write(JSON_PROP_DESC);
-                writer.write(JsonHelper.encode(Option.DESCRIPTION.getJdbcxValue(props)));
+                writer.write(JsonHelper.encode(str));
             }
-        } catch (Exception e) {
-            // ignore
+
+            if (DB_EXTENSIONS.contains(extension)) {
+                try (Connection c = JdbcInterpreter.getConnectionByConfig(props, null)) {
+                    writer.write(',');
+                    final DatabaseMetaData metaData = c.getMetaData();
+                    str = JdbcInterpreter.getDatabaseProduct(metaData);
+                    if (!Checker.isNullOrEmpty(str)) {
+                        writer.write(str);
+                        writer.write(',');
+                    }
+                    writer.write(JdbcInterpreter.getDatabaseCatalogs(metaData, name,
+                            JdbcInterpreter.DEFAULT_TABLE_PATTERN, JdbcInterpreter.DEFAULT_TABLE_TYPES));
+                }
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
         }
         writer.write('}');
     }

--- a/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
+++ b/server/src/test/java/io/github/jdbcx/server/BaseBridgeServerTest.java
@@ -751,7 +751,7 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         try {
             conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db/nonexist"), config, headers);
             Assert.assertEquals(conn.getResponseCode(), 200);
-            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "{}");
+            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()), "{\"type\":\"db\"}");
         } finally {
             if (conn != null) {
                 conn.disconnect();
@@ -761,8 +761,8 @@ public abstract class BaseBridgeServerTest extends BaseIntegrationTest {
         try {
             conn = web.openConnection(Utils.toURL(this.server.getBaseUrl() + "config/db/my-sqlite"), config, headers);
             Assert.assertEquals(conn.getResponseCode(), 200);
-            Assert.assertEquals(Stream.readAllAsString(conn.getInputStream()),
-                    "{\"id\":\"my-sqlite\",\"aliases\":[\"local-sqlite\",\"private-sqlite\"],\"description\":\"SQLite for local development\"}");
+            Assert.assertTrue(Stream.readAllAsString(conn.getInputStream()).startsWith(
+                    "{\"type\":\"db\",\"id\":\"my-sqlite\",\"aliases\":[\"local-sqlite\",\"private-sqlite\"],\"description\":\"SQLite for local development\","));
         } finally {
             if (conn != null) {
                 conn.disconnect();


### PR DESCRIPTION
Now `/config/<datasource id>` will return more information for database servers. For example:
```json
{
  "catalogs": [
    { "name": "memory", "schemas": [{ "name": "main", "tables": [] }] },
    {
      "name": "system",
      "schemas": [
        { "name": "information_schema", "tables": [] },
        { "name": "main", "tables": [] },
        { "name": "pg_catalog", "tables": [] }
      ]
    },
    { "name": "temp", "schemas": [{ "name": "main", "tables": [] }] }
  ]
}
```